### PR TITLE
Use cache clearing for production build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ serve:
 	--disableFastRender
 
 production-build:
-	hugo
+	hugo --gc
 
 preview-build:
 	hugo --baseURL $(DEPLOY_PRIME_URL)

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 title        = "SPIFFE"
-baseURL      = "/"
+baseURL      = "https://spiffe.io"
 languageCode = "en-us"
 pygmentsStyle = "monokai"
 pygmentsCodefences = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,5 @@ HUGO_VERSION = "0.53"
 [context.deploy-preview]
 command = "make preview-build"
 
+[context.branch-deploy]
+command = "make preview-build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,10 @@
 [build]
 publish = "public"
-command = "hugo"
+command = "make production-build"
 
 [build.environment]
 HUGO_VERSION = "0.53"
 
 [context.deploy-preview]
-command = "hugo --baseURL $DEPLOY_PRIME_URL"
+command = "make preview-build"
 
-[context.branch-deploy]
-command = "hugo --baseURL $DEPLOY_PRIME_URL"


### PR DESCRIPTION
There's a lingering issue, pointed out in #36, where Hugo isn't re-fetching JSON from the GitHub Releases API. The `--gc` may help with this issue but I'm not sure, as I'll need to do some more investigation of Netlify's build infrastructure.