### PR TITLE
Make integrity checking optional

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ hrefTargetBlank = true
 
 [params]
 acronym = "Secure Production Identity Framework for Everyone"
+assetintegritychecking = false
 
 [params.home]
 acronym     = "**S**ecure **P**roduction **I**dentity **F**ramework **f**or **E**veryone"

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,4 +1,5 @@
 {{- $inServerMode := .Site.IsServer }}
+{{- $integCheck   := .Site.Params.assetintegritychecking }}
 {{- $sass         := "sass/style.sass" }}
 {{- $cssOutput    := "css/style.css" }}
 {{- $includes     := (slice "node_modules") }}
@@ -10,5 +11,5 @@
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 {{- else }}
 {{- $prodCss := $css | fingerprint }}
-<link rel="stylesheet" href="{{ $prodCss.RelPermalink }}" integrity="{{ $prodCss.Data.Integrity }}">
+<link rel="stylesheet" href="{{ $prodCss.RelPermalink }}"{{ if $integCheck }} integrity="{{ $prodCss.Data.Integrity }}"{{ end }}>
 {{- end }}

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -1,6 +1,7 @@
+{{- $integCheck   := .Site.Params.assetintegritychecking }}
 {{- $jsFiles := .Site.Params.assets.js }}
 {{- range $jsFiles }}
 {{- $path := printf "js/%s.js" . }}
 {{- $js := resources.Get $path | minify | fingerprint }}
-<script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}"></script>
+<script src="{{ $js.RelPermalink }}"{{ if $integCheck }} integrity="{{ $js.Data.Integrity }}"{{ end }}></script>
 {{- end }}


### PR DESCRIPTION
This makes the web resource integrity checking optional (and disables it). To re-enable, set `assetintegritychecking` to `true`.