### PR TITLE
Fixes section link in `getting-started-linux.md`

### DIFF
--- a/content/spire/getting-started-linux.md
+++ b/content/spire/getting-started-linux.md
@@ -268,7 +268,7 @@ On this machine, we have assumed our workload can be most easily identified by i
 		-selector unix:uid:${workload user id from previous step}
 	```
 
-You can now [retrieve the SVID via the Workload API](#step-8:-retrieve-workload-svids). 
+You can now [retrieve the SVID via the Workload API](#step-8-retrieve-workload-svids). 
 
 ### More on Registration Entries
 


### PR DESCRIPTION
The link to section `#step-8-retrieve-workload-svids` includes the ':' after "Step 8" but that colon is stripped out during markdown processing. This PR fixes that link.