### PR TITLE
update custom server and agent plugins reference to examples in spire repo

### DIFF
--- a/content/spire/overview.md
+++ b/content/spire/overview.md
@@ -68,7 +68,7 @@ You customize the agent’s behavior by configuring plugins and other configurat
 
 You can create custom server and agent plugins for particular platforms and architectures for which SPIRE doesn’t include plugins. For example, you could create server and agent node attestors for an architecture other than those summarized under [Node Attestation](#node-attestation). Or you could create a custom datastore plugin to support a type of database SPIRE doesn’t currently support. Because SPIRE loads custom plugins at runtime, you need not recompile SPIRE in order to enable them. 
 
-For help creating custom server and agent plugins, see the [SPIRE Plugin Development guide](https://github.com/spiffe/plugin-template/blob/master/SPIRE_PLUGIN_GUIDE.md). 
+For help creating custom server and agent plugins, see [`examples/plugins`directory in spire repo](https://github.com/spiffe/spire/tree/master/examples/plugins). 
 
 # A Day in the Life of an SVID
 


### PR DESCRIPTION
https://github.com/spiffe/plugin-template/blob/master/SPIRE_PLUGIN_GUIDE.md is not well maintained.

spire repo provides a handy reference for custom plugin implementation.  This is not a comprehensive document guide but it seems to be the most appropriate reference for now.

Although I think we need updated plugin development guide as https://github.com/spiffe/spiffe.io/issues/67 described,  I think spiffe.io should keep being compatible with the latest release.