### PR TITLE
Updates related to SPIRE #1243

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -47,7 +47,7 @@ To build the `spire-agent` and `spire-server` binaries from source:
 $ make all
 ```
 
-The built binaries are available in `cmd/spire-agent/spire-agent` and `cmd/spire-server/spire-server`, respectively.
+The built binaries are available in `bin/spire-agent` and `bin/spire-server`, respectively.
 
 ## Getting help
 

--- a/content/spire/getting-started-linux.md
+++ b/content/spire/getting-started-linux.md
@@ -91,24 +91,11 @@ To install the server and agent:
 2. Add `spire-server` and `spire-agent` to your $PATH for convenience:
 
 	```shell
-	ln -s /opt/spire/spire-server /usr/bin/spire-server
-	ln -s /opt/spire/spire-agent /usr/bin/spire-agent
+	sudo ln -s /opt/spire/spire-server /usr/bin/spire-server
+	sudo ln -s /opt/spire/spire-agent /usr/bin/spire-agent
 	```
 
 ## Step 4: Configure the Server {#step-4}
-
-To configure the server you:
-
-1. Configure the trust domain
-2. Configure the server certificate authority (CA), which might include configuring an UpstreamCA plugin 
-3. Configure the node attestation plugin
-4. Configure a default **.data** directory for persisting data
-
-However, to get a simple deployment up and running for demonstration purposes, you need only go through steps 1, 2, and 3. 
-
-To configure the items in steps 1, 2, and 3, edit the server’s configuration file, located in **/opt/spire/conf/server/server.conf**.
-
-If you choose to change the default data directory, you do this at the command line.  
 
 ### Configure the Server’s Trust Domain
 
@@ -117,25 +104,6 @@ To configure the server’s trust domain:
 1. Edit the server’s configuration file in  **/opt/spire/conf/server/server.conf**
 2. Locate the section labeled **trust_domain**  
 3. Enter the trust domain name you decided on in the [Plan Your Configuration](#plan-your-configuration) section above. 
-
-### Configure the Trusted Root CA Plugin
-
-Every SVID issued by a SPIRE installation is issued from a common trust root. SPIRE provides a pluggable mechanism for retrieving this trust root. By default, it uses a key stored on disk. 
-
-You configure the plugin by editing the `UpstreamCA “disk”` entry in the server configuration file:
-
-1. Edit the server’s configuration file in  **/opt/spire/conf/server/server.conf**
-2. Locate the **UpstreamCA "disk" { .. }** plugin in the **plugins{...}** section
-3. Modify the  **key_file_path** and **cert_file_path** appropriately
-
-For simplicity’s sake, here we illustrate CA plugin configuration using a dummy CA key provided in SPIRE, setting the paths as follows:
-
-```shell
-key_file_path = "/opt/spire/conf/server/dummy_upstream_ca.key"
-cert_file_path = "/opt/spire/conf/server/dummy_upstream_ca.crt"
-```
-
-When you customize these instructions for your architecture, you will substitute the appropriate path values to point to your application’s key and certs.
 
 ### Configure Server Plugins
 
@@ -147,11 +115,15 @@ As described above in the [Plan Your Configuration](#plan-your-configuration) se
 
 For simplicity’s sake, this guide illustrates node attestation using the join token method. Note that SPIRE ships with the default node attestation method set to join token. 
 
-Pre-built binaries must reside in a **.data** directory. Create this directory in the location of your choice. For example: 
+### Configure Data Directory
 
-```shell
-sudo mkdir -p /opt/spire/.data
-```
+The example configuration files included in the release tarball persist data under the `./data/server` directory (as in the `data` directory in the working directory where the SPIRE server is executed). For the purposes of this guide, we want to instead persist data under `/opt/spire/data/server`.
+
+To do so:
+
+1. Edit the server’s configuration file in **/opt/spire/conf/server/server.conf**
+2. Identity paths in the configuration starting with `./data/server`
+3. Replace `./data/server` prefix on those paths with `/opt/spire/data/server`
 
 ### Server Configuration Reference
 
@@ -159,19 +131,17 @@ For a complete server configuration reference, see the [SPIRE Server Configurati
 
 ## Step 5: Configure the Agent {#step-5}
 
-When connecting to the SPIRE Server for the first time, the agent uses a configured X.509 CA certificate to verify the initial connection. SPIRE releases include a "dummy" certificate for this purpose. For a production implementation, a separate key should be generated. See the [next section](#generate-a-key).
+When connecting to the SPIRE Server for the first time, the agent typically uses a configured trust bundle to trust the server certificate. For demonstration purposes, the agent will be configured to skip this verification step. **For production use** the agent should be configured with a path to the trust bundle (see `trust_bundle_path` [here](https://github.com/spiffe/spire/blob/master/doc/spire_agent.md#agent-configuration-file))
 
-### Generate a Key
+### Configure Data Directory
 
-Use the tool of your choice -- such as openssl, cfssl, or an equivalent tool -- to generate a key for the server and certificate, to be bundled with the agent. 
+The example configuration files included in the release tarball persist data under the `./data/agent` directory (as in the `data` directory in the working directory where the SPIRE Agent is executed). For the purposes of this guide, we want to instead persist data under `/opt/spire/data/agent`.
 
-### Configure the Trust Bundle Path
+To do so:
 
-To configure the trust bundle on the agent side, edit the configuration file  so that the agent looks for the trust bundle at the correct path:
-
-1. Edit the agent’s configuration file in  **/opt/spire/conf/agent/agent.conf**
-2. Locate the **trust_bundle_path = { .. }** entry 
-3. Set the value to  **/opt/spire/conf/agent/dummy_root_ca.crt**
+1. Edit the agent’s configuration file in **/opt/spire/conf/agent/agent.conf**
+2. Identity paths in the configuration starting with `./data/agent`
+3. Replace `./data/agent` prefix on those paths with `/opt/spire/data/agent`
 
 ### Configure Agent Plugins
 

--- a/content/spire/getting-started-linux.md
+++ b/content/spire/getting-started-linux.md
@@ -24,9 +24,9 @@ To review these concepts, see the [SPIFFE/SPIRE Overview](https://spiffe.io/spir
 
 ### Assumptions
 
-This walkthrough demonstrates how to deploy SPIRE to identify a single workload running on a node running Linux. It sets up the SPIRE Server and SPIRE Agent so that they’re running on the same node. In an actual deployment, these would typically run on different nodes.  
+This walkthrough demonstrates how to deploy SPIRE to identify a single workload running on a node running Linux. It sets up the SPIRE Server and SPIRE Agent so that they’re running on the same node. In an actual deployment, these would typically run on different nodes.
 
-In the walkthrough, the workload to which SPIRE will issue an identity is running under a specific UNIX user id; SPIRE users will use this user id to generate an SVID for the workload. 
+In the walkthrough, the workload to which SPIRE will issue an identity is running under a specific UNIX user id; SPIRE users will use this user id to generate an SVID for the workload.
 
 This guide also illustrates node attestation using join tokens---a pre-shared key between a server and an agent---the simplest node attestation strategy.
 
@@ -36,27 +36,27 @@ Finally, this guide assumes the user is running **Ubuntu 16.04**.
 
 ### Plan Your Configuration
 
-To customize the behavior of the SPIRE Server and SPIRE Agent to meet your application’s needs you edit configuration files for the server and agent. 
+To customize the behavior of the SPIRE Server and SPIRE Agent to meet your application’s needs you edit configuration files for the server and agent.
 
-Note that the some of the configuration file default settings -- such as those for database choice for server data, key management backend, and upstream -- will work well for most evaluations. 
+Note that the some of the configuration file default settings -- such as those for database choice for server data, key management backend, and upstream -- will work well for most evaluations.
 
-The following decisions influence how you set values in the configuration file: 
+The following decisions influence how you set values in the configuration file:
 
-* What you will name your server trust domain and your agent trust domain 
+* What you will name your server trust domain and your agent trust domain
 
-Trust domain names must be identical in the server and the agent. 
+Trust domain names must be identical in the server and the agent.
 
-* Which node attestation method your application requires 
+* Which node attestation method your application requires
 
-This depends on your where your workload is running. Your choice of node attestation method determines which node-attestor plugins you configure SPIRE to use in Server Plugins and Agent Plugins sections of the SPIRE configuration files. You must configure at least one node attestor on the server and only one node attestor on the agent. 
+This depends on your where your workload is running. Your choice of node attestation method determines which node-attestor plugins you configure SPIRE to use in Server Plugins and Agent Plugins sections of the SPIRE configuration files. You must configure at least one node attestor on the server and only one node attestor on the agent.
 
-For simplicity’s sake, this guide demonstrates using the join token method for node attestation. 
+For simplicity’s sake, this guide demonstrates using the join token method for node attestation.
 
 * Which workload attestation method your application requires. As with node attestation methods, your choice depends on the infrastructure your application’s workloads are deployed in (for example, SPIRE supports identifying workloads that run in Kubernetes).
 
 * Which type of database your application will use to store server data
 
-SPIRE employs a database to persist data related to workload identities and registration entries. By default, SPIRE bundles SQLite and sets it as the default for storage of server data. SPIRE currently also supports PostgreSQL. For production purposes, you should carefully consider which database to use. 
+SPIRE employs a database to persist data related to workload identities and registration entries. By default, SPIRE bundles SQLite and sets it as the default for storage of server data. SPIRE currently also supports PostgreSQL. For production purposes, you should carefully consider which database to use.
 
 * Which key management backend your application requires
 
@@ -66,7 +66,7 @@ The key manager generates and persists the public-private key pair used for the 
 
 The SPIRE server provides a CA. If you’re, for example, using an external PKI system that provides an upstream CA, you can configure SPIRE to use that instead.
 
-Once you’ve made these decisions, you can [configure the server](#step-4) and [configure the agent](#step-5) accordingly, after [installing them](#step-3-install-the-server-and-agent). 
+Once you’ve made these decisions, you can [configure the server](#step-4) and [configure the agent](#step-5) accordingly, after [installing them](#step-3-install-the-server-and-agent).
 
 ## Step 2: Obtain the SPIRE Binaries {#step-2}
 
@@ -76,7 +76,7 @@ If you wish, you may also [build SPIRE from source](https://github.com/spiffe/sp
 
 ## Step 3: Install the Server and Agent {#step-3}
 
-As stated above, this guide illustrates installs the server and agent on the same node. More typically, your architecture will have the the server installed on one node and one or more agents installed on distinct nodes. 
+As stated above, this guide illustrates installs the server and agent on the same node. More typically, your architecture will have the the server installed on one node and one or more agents installed on distinct nodes.
 
 To install the server and agent:
 
@@ -91,29 +91,25 @@ To install the server and agent:
 2. Add `spire-server` and `spire-agent` to your $PATH for convenience:
 
 	```shell
-	sudo ln -s /opt/spire/spire-server /usr/bin/spire-server
-	sudo ln -s /opt/spire/spire-agent /usr/bin/spire-agent
+	sudo ln -s /opt/spire/bin/spire-server /usr/bin/spire-server
+	sudo ln -s /opt/spire/bin/spire-agent /usr/bin/spire-agent
 	```
 
 ## Step 4: Configure the Server {#step-4}
+
+To configure the server you:
+
+1. Configure the trust domain
+3. Configure a directory to use for persisting data
+2. Configure the plugins
 
 ### Configure the Server’s Trust Domain
 
 To configure the server’s trust domain:
 
 1. Edit the server’s configuration file in  **/opt/spire/conf/server/server.conf**
-2. Locate the section labeled **trust_domain**  
-3. Enter the trust domain name you decided on in the [Plan Your Configuration](#plan-your-configuration) section above. 
-
-### Configure Server Plugins
-
-As described above in the [Plan Your Configuration](#plan-your-configuration) section, before installing and configuring you determine which plugin you configure the server to use for node attestation. You must edit the configuration file to point to the path to the binary of the plugin your application will use. 
-
-1. Edit the server’s configuration file in **/opt/spire/conf/server/server.conf**
-2. Locate the **plugin_cmd = { .. }** entry in the **plugins { ... }** section 
-3. Set the value to the path to your plugin binary 
-
-For simplicity’s sake, this guide illustrates node attestation using the join token method. Note that SPIRE ships with the default node attestation method set to join token. 
+2. Locate the section labeled **trust_domain**
+3. Enter the trust domain name you decided on in the [Plan Your Configuration](#plan-your-configuration) section above.
 
 ### Configure Data Directory
 
@@ -125,11 +121,26 @@ To do so:
 2. Identity paths in the configuration starting with `./data/server`
 3. Replace `./data/server` prefix on those paths with `/opt/spire/data/server`
 
+### Configure Server Plugins
+
+As described above in the [Plan Your Configuration](#plan-your-configuration) section, before installing and configuring you determine which plugin you configure the server to use for node attestation. You must edit the configuration file to point to the path to the binary of the plugin your application will use.
+
+1. Edit the server’s configuration file in **/opt/spire/conf/server/server.conf**
+2. Locate the **plugin_cmd = { .. }** entry in the **plugins { ... }** section
+3. Set the value to the path to your plugin binary
+
+For simplicity’s sake, this guide illustrates node attestation using the join token method. Note that SPIRE ships with the default node attestation method set to join token.
+
 ### Server Configuration Reference
 
 For a complete server configuration reference, see the [SPIRE Server Configuration Reference](https://github.com/spiffe/spire/blob/master/doc/spire_server.md).
 
 ## Step 5: Configure the Agent {#step-5}
+
+To configure the agent you:
+
+1. Configure a directory to use for persisting data
+2. Configure the plugins
 
 When connecting to the SPIRE Server for the first time, the agent typically uses a configured trust bundle to trust the server certificate. For demonstration purposes, the agent will be configured to skip this verification step. **For production use** the agent should be configured with a path to the trust bundle (see `trust_bundle_path` [here](https://github.com/spiffe/spire/blob/master/doc/spire_agent.md#agent-configuration-file))
 
@@ -145,7 +156,7 @@ To do so:
 
 ### Configure Agent Plugins
 
-As described above in the [Plan Your Configuration](#plan-your-configuration) section, before installing and configuring you determine which plugin you configure the agent to use for node attestation and workload attestation. 
+As described above in the [Plan Your Configuration](#plan-your-configuration) section, before installing and configuring you determine which plugin you configure the agent to use for node attestation and workload attestation.
 
 #### Node Attestor Plugin
 
@@ -153,7 +164,7 @@ As described above in the [Plan Your Configuration](#plan-your-configuration) se
 The agent node attestor plugin must match the node attestor plugin type you choose when you configured the server.
 {{< /warning >}}
 
-For simplicity’s sake, this guide illustrates node attestation using the join token method. As this is SPIRE’s default configuration setting for node attestation, you do not need to make changes to the node attestation plugins section in the agent configuration file. 
+For simplicity’s sake, this guide illustrates node attestation using the join token method. As this is SPIRE’s default configuration setting for node attestation, you do not need to make changes to the node attestation plugins section in the agent configuration file.
 
 #### Workload Attestor Plugin
 
@@ -163,13 +174,13 @@ This guide’s example uses UNIX as a workload attestor plugin. For this reason,
 
 #### Datastore Plugin
 
-As described above in the [Plan Your Configuration](#plan-your-configuration) section, before installing and configuring you determine whether SPIRE’s default datastore plugin -- SQLite3 -- is sufficient for your application. For high availability, in which you might have multiple SPIRE servers running against your database, you may want to choose the Postgres datastore plugin. 
+As described above in the [Plan Your Configuration](#plan-your-configuration) section, before installing and configuring you determine whether SPIRE’s default datastore plugin -- SQLite3 -- is sufficient for your application. For high availability, in which you might have multiple SPIRE servers running against your database, you may want to choose the Postgres datastore plugin.
 
 If your application required that, you would need to edit the DataStore entry in the **plugins** section of the **/opt/spire/conf/server/server.conf** file to specify the Postgres plugin.
 
 #### Keymanager Plugin
 
-During node attestation, the server assigns the agent a SVID; the agent must store a private key for that SVID. The agent receives a signed certificate and must choose between storing it in memory or on disk. 
+During node attestation, the server assigns the agent a SVID; the agent must store a private key for that SVID. The agent receives a signed certificate and must choose between storing it in memory or on disk.
 
 The advantage of storing it on disk is that the is no need to redo node attestation if the agent is restarted.
 
@@ -185,11 +196,11 @@ For a complete discussion of agent configuration values, see the section [SPIRE 
 
 ## Step 6: Start Up the Server and Agent {#step-6}
 
-In this example, we will start a server and join an agent to it using the join token attestation method. 
+In this example, we will start a server and join an agent to it using the join token attestation method.
 
 Here are the steps:
 
-1. Start up the server, passing in the path to the server configuration file: 
+1. Start up the server, passing in the path to the server configuration file:
 
 	```shell
 	sudo spire-server run  -config /opt/spire/conf/server/server.conf
@@ -204,13 +215,13 @@ Here are the steps:
 
 The default Time to Live (ttl) for the join token is 600 seconds. To overwrite the default, pass a different value via the **-ttl** option to the `spire-server token generate` command.
 
-2. Staying in the same terminal, start up the agent, passing in the path to the agent configuration file, as well as the join token you just generated. 
+2. Staying in the same terminal, start up the agent, passing in the path to the agent configuration file, as well as the join token you just generated.
 s
 	```shell
 	sudo spire-agent run -config /opt/spire/conf/agent/agent.conf -joinToken aaaaaaaa-bbbb-cccc-dddd-111111111111
 	```
 
-You have the option to adding the join token to the **NodeAttestor** entry in the agent configuration file instead of passing it at the command line. 
+You have the option to adding the join token to the **NodeAttestor** entry in the agent configuration file instead of passing it at the command line.
 
 ## Step 7 Register Workloads
 
@@ -238,14 +249,14 @@ On this machine, we have assumed our workload can be most easily identified by i
 		-selector unix:uid:${workload user id from previous step}
 	```
 
-You can now [retrieve the SVID via the Workload API](#step-8-retrieve-workload-svids). 
+You can now [retrieve the SVID via the Workload API](#step-8-retrieve-workload-svids).
 
 ### More on Registration Entries
 
 The contents of a registration entry vary depending on the platform the workload is running on, but all workload registration entries contain:
 
-the parent ID:  the agent’s SPIFFE ID, which tells SPIRE which agent this workload belongs to  
-a ttl for the SVID issued 
+the parent ID:  the agent’s SPIFFE ID, which tells SPIRE which agent this workload belongs to
+a ttl for the SVID issued
 
 Because this guide assumes we’re running on UNIX, we also specify the following selectors:
 
@@ -259,14 +270,14 @@ Not that the minimum requirement for a UNIX kernel selector is just one of these
 
 At this point, the registration API has been called and the target workload has been registered with the SPIRE Server. We can now call the workload API using a command line program to request the workload’s SVID from the agent, as illustrated in the next section.
 
-### Simple Illustration: Retrieve a Workload’s SVID 
+### Simple Illustration: Retrieve a Workload’s SVID
 
 If you’re curious to see the contents of a workload SVID, follow the instructions in this section to retrieve the SVID bundle and then write the SVID and key to disk, in order to examine them in detail with openssl.
 
 {{< info >}}
 To confirm that OpenSSL is installed, run `sudo dpkg -l openssl`. If it is not installed, install it with `sudo apt -y install openssl`.
 {{< /info >}}
- 
+
 We simulate the workload API interaction and retrieve the workload SVID bundle by running the `api` subcommand in the agent. Run the command as the user `workload` that we created in the previous section.
 
 {{< info >}}


### PR DESCRIPTION
- Updates paths to SPIRE binaries built via the SPIRE Makefile
- Removes UpstreamCA and agent bootstrap related text
- Updates texts to require configuration of the data directory for SPIRE Server and SPIRE Agent