### PR TITLE
Adds hotjar tracking code

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,6 +8,17 @@
     <link rel="shortcut icon" href="{{ $favicon }}" type="image/x-icon">
     {{ partial "css.html" . }}
     <script src="https://unpkg.com/tippy.js@3/dist/tippy.all.min.js"></script>
+    <!-- Hotjar Tracking Code for spiffe.io -->
+    <script>
+      (function(h,o,t,j,a,r){
+          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+          h._hjSettings={hjid:1580598,hjsv:6};
+          a=o.getElementsByTagName('head')[0];
+          r=o.createElement('script');r.async=1;
+          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+          a.appendChild(r);
+      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    </script>
   </head>
   <body class="is-page is-{{ $pageType }}-page has-navbar-fixed-top">
     {{ partial "navbar.html" . }}


### PR DESCRIPTION
This change adds tracking code for hotjar.com so we can display polls to users to gauge how the documentation could be further improved.

We're conscious of adding tracking code to an OSS property, and so wanted to explain specifically what this being used for:

We are using hotjar for the sole purpose of displaying polls to gauge how useful the spiffe.io project is to users, and collect feedback on how we can improve project. We're specifically trying to find out how immediately useful SPIFFE is to users from reading the documentation, and identifying areas where the documentation can be improved.

Beyond submitted poll data we won't be using hotjar to collect any user data, and no data collected through this service will be used for any kind of re-marketing.