### PR TITLE
Fix GitHub API rate limiting issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,7 @@ preview-build:
 	hugo --baseURL $(DEPLOY_PRIME_URL)
 
 docker-serve:
+	docker run --rm -it -v $(PWD):/src -p 1313:1313 -e HIDE_RELEASES=true klakegg/hugo:latest-ext server --buildDrafts --buildFuture
+
+docker-serve-with-releases:
 	docker run --rm -it -v $(PWD):/src -p 1313:1313 klakegg/hugo:latest-ext server --buildDrafts --buildFuture

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,18 @@ setup:
 	npm install
 
 serve:
-	hugo server \
+	HIDE_RELEASES=true hugo server \
 	--buildDrafts \
 	--buildFuture \
 	--disableFastRender \
 	--ignoreCache \
 	--noHTTPCache
+
+serve-with-releases:
+	hugo server \
+	--buildDrafts \
+	--buildFuture \
+	--disableFastRender
 
 production-build:
 	hugo --gc

--- a/layouts/shortcodes/releases.html
+++ b/layouts/shortcodes/releases.html
@@ -1,9 +1,8 @@
+{{- $displayReleases  := ne (getenv "HIDE_RELEASES") "true" }}
 {{- $spireReleasesUrl := "https://api.github.com/repos/spiffe/spire/releases" }}
 {{- $downloadUrl      := "https://github.com/spiffe/spire/releases/download" }}
-{{- $releases         := getJSON $spireReleasesUrl }}
-{{- $latest           := (index $releases 0).tag_name }}
-{{- $clipboardButtons := .Site.Params.downloads.buttons.clipboard }}
-{{- $downloadButtons  := .Site.Params.downloads.buttons.download }}
+
+{{- if $displayReleases }}
 <table class="is-downloads-table">
   <thead>
     <tr>
@@ -19,7 +18,12 @@
     </tr>
   </thead>
   <tbody>
+    {{- $releases         := getJSON $spireReleasesUrl }}
     {{- range $releases }}
+    {{- $latest           := (index $releases 0).tag_name }}
+    {{- $clipboardButtons := .Site.Params.downloads.buttons.clipboard }}
+    {{- $downloadButtons  := .Site.Params.downloads.buttons.download }}
+
     {{- $version      := .tag_name }}
     {{- $versionUrl   := .html_url }}
     {{- $isLatest     := eq $version $latest }}
@@ -63,3 +67,8 @@
     {{- end }}
   </tbody>
 </table>
+{{- else }}
+<blockquote>
+  The releases table is not currently displayed because you're running the site in standard development mode. To display the releases table while in development mode, run <code>make serve-with-releases</code> rather than the standard <code>make serve</code>.
+</blockquote>
+{{- end }}

--- a/layouts/shortcodes/spire-latest.html
+++ b/layouts/shortcodes/spire-latest.html
@@ -1,4 +1,9 @@
+{{- $displayReleases  := ne (getenv "HIDE_RELEASES") "true" }}
+{{- if $displayReleases }}
 {{- $releasesUrl := "https://api.github.com/repos/spiffe/spire/releases" }}
 {{- $releases    := getJSON $releasesUrl }}
 {{- $latest      := (index $releases 0).tag_name }}
 {{- $latest -}}
+{{- else -}}
+LATEST
+{{- end -}}


### PR DESCRIPTION
This PR adds separate development modes for pinging the GitHub API for release info vs. not. The default `make serve` command now displays an informational blockquote rather than the releases table. The `make serve-with-releases` command will display the table.

Fixes #93