### PR TITLE
SPIRE OIDC Federation to AWS v3

### DIFF
--- a/content/spire/try/getting-started-k8s.md
+++ b/content/spire/try/getting-started-k8s.md
@@ -147,7 +147,6 @@ In order to enable SPIRE to perform workload attestation -- which allows the age
     $ kubectl exec -n spire spire-server-0 -- \
         /opt/spire/bin/spire-server entry create \
         -spiffeID spiffe://example.org/ns/spire/sa/spire-agent \
-        -parentID spiffe://example.org/spire/server \
         -selector k8s_sat:cluster:demo-cluster \
         -selector k8s_sat:agent_ns:spire \
         -selector k8s_sat:agent_sa:spire-agent \

--- a/content/spire/try/oidc-federation-aws.md
+++ b/content/spire/try/oidc-federation-aws.md
@@ -21,7 +21,7 @@ In this tutorial you will learn how to:
 
 ## Prerequisites
 
-Note the following required accounts, prerequisites, and limitations before starting on this tutorial:
+Note the following required accounts, prerequisites, and limitations before starting this tutorial:
 
 * You'll need access to the Kubernetes environment that you configured when going through [Kubernetes Quickstart](/spire/try/getting-started-k8s/) 
 * You'll need access to the AWS console to configure an identity provider, policy, role, and S3 bucket
@@ -30,9 +30,9 @@ Note the following required accounts, prerequisites, and limitations before star
 
 ### Required DNS A Record for the OIDC Discovery Provider IP Address
 
-The SPIRE OIDC Discovery Provider provides a URL to the location of the discovery document specified by the OIDC protocol. After starting the spire-oidc service you'll need to configure a DNS A record to point to the external IP address of that service. In the YAML files set up for this tutorial, replace MY\_DISCOVERY\_DOMAIN with the FQDN of the planned DNS hostname. The FQDN value for MY\_DISCOVERY\_DOMAIN does not need to correspond to an existing FQDN on your network. It is specific to the Kubernetes environment.
+The SPIRE OIDC Discovery Provider provides a URL to the location of the discovery document specified by the OIDC protocol. After starting the spire-oidc service you'll need to configure a DNS A record to point to the external IP address of that service. In the YAML files set up for this tutorial, replace MY\_DISCOVERY\_DOMAIN with the FQDN of the planned DNS hostname. The FQDN value for MY\_DISCOVERY\_DOMAIN does not need to correspond to an existing domain on your network. It is specific to the Kubernetes environment.
 
-To get the external IP address required for the A record, you will need to proceed through the following steps until you start the spire-oidc service and verify the external IP address in the section [Verify That spire-oidc has an External Service Address](#verify-that-spireoidc-has-an-external-service-address). The DNS A record should take the following form:
+To get the external IP address required for the A record, you will need to proceed through the steps in this tutorial until you start the spire-oidc service and verify the external IP address in the section [Verify That spire-oidc has an External Service Address](#verify-that-spireoidc-has-an-external-service-address). The DNS A record should take the following form:
 
 ```console
 MY_DISCOVERY_DOMAIN          A        EXTERNAL-IP for spire-oidc service
@@ -49,7 +49,7 @@ As with any change to DNS, it will take minutes or hours for the new A record to
 
 Although this tutorial should contain all the info you need, the SPIRE OIDC Discovery Provider configuration file format is described on [GitHub](https://github.com/spiffe/spire/tree/master/support/oidc-discovery-provider).
 
-This tutorial uses Let's Encrypt to configure a certificate for the OIDC Discovery Domain. But other than editing the oidc-dp-configmap.yaml file as described in the previous section, no additional setup steps are required for Let's Encrypt.
+This tutorial uses Let's Encrypt to configure a certificate for the OIDC Discovery Provider domain. But other than editing the oidc-dp-configmap.yaml file as described in the previous section, no additional setup steps are required for Let's Encrypt.
 
 # Part One: Configure SPIRE Components
 
@@ -76,7 +76,7 @@ The SPIRE OIDC Discovery Provider provides a URL to the location of the discover
 
 Before running the command below, ensure that you have replaced the MY\_DISCOVERY\_DOMAIN placeholder with the FQDN of the Discovery Provider as described in [Replace Placeholder Strings in YAML Files](#replace-placeholder-strings-in-yaml-files).
 
-Use the following command to apply the updated server configmap, the configmap for the OIDC Discovery Provider, and deploy the updated **spire-server** statefulset:
+Change to the directory containing the **k8s/oidc-aws** YAML files and use the following command to apply the updated server configmap, the configmap for the OIDC Discovery Provider, and deploy the updated **spire-server** statefulset:
 
 ```console
 $ kubectl apply \
@@ -237,7 +237,12 @@ To allow the workload from outside AWS to access AWS S3, add the workload's SPIF
 
 3. Click the **Trust relationships** tab near the middle of the page and then click **Edit trust relationship**.
 
-4. In the JSON access control policy, add a condition line at the end of the `StringEquals` attribute to restrict access to workloads matching the workload SPIFFE ID that was assigned in the [Kubernetes Quickstart](/spire/try/getting-started-k8s/). Use the form shown below but substitute your Discovery Provider FQDN for MY\_DISCOVERY\_DOMAIN. Add a comma at the end of the previous line after `"mys3"`.
+4. In the JSON access control policy, add a condition line at the end of the `StringEquals` attribute to restrict access to workloads matching the workload SPIFFE ID that was assigned in the [Kubernetes Quickstart](/spire/try/getting-started-k8s/). The new line to add is:
+
+   ```json
+   "MY_DISCOVERY_DOMAIN:sub": "spiffe://example.org/ns/default/sa/default"
+   ```
+   But substitute your Discovery Provider FQDN for MY\_DISCOVERY\_DOMAIN. Add a comma at the end of the previous line after `"mys3"`. When finished, the JSON should look similar to:
 
    ```json
    {
@@ -260,7 +265,7 @@ To allow the workload from outside AWS to access AWS S3, add the workload's SPIF
    }
    ```
 
-5. Click **Update Trust Policy**.
+5. Click **Update Trust Policy**. This change to the IAM role takes a minute or two to propagate.
 
 ## Create an AWS S3 Test File
 
@@ -339,6 +344,7 @@ Now that Kubernetes and AWS are configured for OIDC federation, we'll test the c
    ```console
    # cat test.txt
    oidc-tutorial file
+   ```
 
 9. Exit from `/bin/sh` on the client container:
 
@@ -364,7 +370,7 @@ In a production environment, you will need a way to automatically refresh the JW
 
 ### (NotFound) Error
 
-If in step 2 you get an error message that includes `(NotFound)`, be sure to substitute your client pod name instead of using the example pod shown in step 2.
+If in step 2 you get an error message that includes `(NotFound)`, be sure to substitute your client pod name instead of using the example pod shown there.
 
 ### General Troubleshooting
 
@@ -406,4 +412,4 @@ Delete the policy, role, and S3 bucket that you configured for this tutorial.
 
 ## DNS Cleanup
 
-You can remove the A record that you configured for the SPIRE OIDC Discovery Provider document location.
+Remove the A record that you configured for the SPIRE OIDC Discovery Provider document location.

--- a/content/spire/try/oidc-federation-aws.md
+++ b/content/spire/try/oidc-federation-aws.md
@@ -295,7 +295,7 @@ Create a simple test file in an AWS S3 bucket to use for testing.
 
 9. Click **Upload**.
 
-# Part 3: Test Access to AWS S3
+# Part Three: Test Access to AWS S3
 
 Now that Kubernetes and AWS are configured for OIDC federation, we'll test the connection. This test retrieves a JWT SVID from the SPIRE Agent and uses the JWT token in the JWT SVID to access S3.
 
@@ -352,9 +352,9 @@ Now that Kubernetes and AWS are configured for OIDC federation, we'll test the c
    # exit
    ```
 
-## Troubleshooting s3 Testing
+## Troubleshooting S3 Testing
 
-If you ran into a problem testing access to the s3 `test.txt` file, see the following sections for possible solutions.
+If you ran into a problem testing access to the `test.txt` file in S3, see the following sections for possible solutions.
 
 ### An error occurred (403) Error
 

--- a/content/spire/try/oidc-federation-aws.md
+++ b/content/spire/try/oidc-federation-aws.md
@@ -87,9 +87,9 @@ As part of this tutorial, you will need to register a public DNS record that wil
 
 In this tutorial, the subdomain that you create will provide an endpoint to the discovery document specified by the OIDC protocol. AWS will query this endpoint as part of the authentication handshake between AWS and SPIRE.
 
-## Display the External Service Address of spire-oidc
+## Retrieve the IP Address of the SPIRE OIDC Discovery Provider
 
-Run the following command to display the external IP address of the spire-oidc service. The spire-oidc Discovery Provider service must provide an external IP address for AWS to access the OIDC Discovery document provided by spire-oidc.
+Run the following command to retrieve the external IP address of the spire-oidc service. The spire-oidc Discovery Provider service must provide an external IP address for AWS to access the OIDC Discovery document provided by spire-oidc.
 
 ```console
 $ kubectl get service -n spire spire-oidc

--- a/content/spire/try/oidc-federation-aws.md
+++ b/content/spire/try/oidc-federation-aws.md
@@ -23,9 +23,8 @@ In this tutorial you will learn how to:
 
 Note the following required accounts, prerequisites, and limitations before starting this tutorial:
 
-* You'll need access to the Kubernetes environment that you configured when going through [Kubernetes Quickstart](/spire/try/getting-started-k8s/) 
-* You'll need access to the AWS console with an account that has permissions to configure an identity provider, IAM policy, IAM role, and S3 bucket
-* This tutorial cannot run on Minikube as the Kubernetes environment must be network accessible by AWS
+* You'll need access to the Kubernetes environment that you configured when going through [Kubernetes Quickstart](/spire/try/getting-started-k8s/). The Kubernetes environment must be able to expose an Ingress to the public internet. _Note: This is generally not true for local Kubernetes environments such as Minikube._
+* You'll need access to the AWS console with an account that has permissions to configure an identity provider, IAM policy, IAM role, and S3 bucket.
 * You'll need the ability to configure a DNS A record for the SPIRE OIDC Discovery document endpoint (see [Part 2](#part-2-configure-dns-for-the-oidc-discovery-provider-ip-address))
 
 

--- a/content/spire/try/oidc-federation-aws.md
+++ b/content/spire/try/oidc-federation-aws.md
@@ -34,7 +34,7 @@ In the first part of this procedure, you configure the SPIRE components in Kuber
 
 ## Download Kubernetes YAML Files for this Tutorial
 
-To get the YAML files required for this tutorial, clone https://github.com/spiffe/spire-tutorials. The files for this tutorial are in the **k8s/oidc-aws** directory.
+To get the YAML files required for this tutorial, clone https://github.com/spiffe/spire-tutorials. The files for this tutorial are in the `k8s/oidc-aws` directory.
 
 ## Replace Placeholder Strings in YAML Files
 
@@ -53,7 +53,7 @@ The SPIRE OIDC Discovery Provider provides a URL to the location of the discover
 
 Before running the command below, ensure that you have replaced the MY\_DISCOVERY\_DOMAIN placeholder with the FQDN of the Discovery Provider as described in [Replace Placeholder Strings in YAML Files](#replace-placeholder-strings-in-yaml-files).
 
-Change to the directory containing the **k8s/oidc-aws** YAML files and use the following command to apply the updated server configmap, the configmap for the OIDC Discovery Provider, and deploy the updated **spire-server** statefulset:
+Change to the directory containing the `k8s/oidc-aws` YAML files and use the following command to apply the updated server configmap, the configmap for the OIDC Discovery Provider, and deploy the updated **spire-server** statefulset:
 
 ```console
 $ kubectl apply \
@@ -62,11 +62,16 @@ $ kubectl apply \
     -f server-statefulset.yaml
 ```
 
-To verify that the spire-server pod has spire-server and spire-oidc containers, run:
+To verify that the **spire-server** pod has **spire-server** and **spire-oidc** containers, run:
 
 ```console
 $ kubectl get pods -n spire -l app=spire-server -o \
     jsonpath='{.items[*].spec.containers[*].name}{"\n"}'
+```
+
+This should output:
+
+```console
 spire-server spire-oidc
 ```
 
@@ -83,13 +88,13 @@ $ kubectl apply \
 
 # Part 2: Configure DNS for the OIDC Discovery IP Address
 
-As part of this tutorial, you will need to register a public DNS record that will resolve to the public IP address of your Kubernetes cluster. This will require you or an administrator to have registered a domain name (e.g. yutani.com) with a domain name registrar, have configured its name server to point to a DNS service, and have the ability to create an A record for a new subdomain (e.g. oidc-discovery.yutani.com) in that DNS service. If you don't have a registered domain name or access to a DNS service, services like Google Domains can help you set one up for a fee.
+As part of this tutorial, you will need to register a public DNS record that will resolve to the public IP address of your Kubernetes cluster. This will require you or an administrator to have registered a domain name (e.g. `yutani.com`) with a domain name registrar, have configured its name server to point to a DNS service, and have the ability to create an A record for a new subdomain (e.g. `oidc-discovery.yutani.com`) in that DNS service. If you don't have a registered domain name or access to a DNS service, services like Google Domains can help you set one up for a fee.
 
 In this tutorial, the subdomain that you create will provide an endpoint to the discovery document specified by the OIDC protocol. AWS will query this endpoint as part of the authentication handshake between AWS and SPIRE.
 
 ## Retrieve the IP Address of the SPIRE OIDC Discovery Provider
 
-Run the following command to retrieve the external IP address of the spire-oidc service. The spire-oidc Discovery Provider service must provide an external IP address for AWS to access the OIDC Discovery document provided by spire-oidc.
+Run the following command to retrieve the external IP address of the **spire-oidc** service. The **spire-oidc** Discovery Provider service must provide an external IP address for AWS to access the OIDC Discovery document provided by **spire-oidc**.
 
 ```console
 $ kubectl get service -n spire spire-oidc
@@ -100,7 +105,7 @@ spire-oidc     LoadBalancer   10.12.0.18    34.82.139.13   443:30198/TCP    108s
 
 ## Configure an A Record for the OIDC Discovery Document Endpoint
 
-Using your preferred DNS tool, put the MY\_DISCOVERY\_DOMAIN domain and the spire-oidc external IP address in a new DNS A record. The A record should take the following form:
+Using your preferred DNS tool, put the MY\_DISCOVERY\_DOMAIN domain and the **spire-oidc** external IP address in a new DNS A record. The A record should take the following form:
 
 ```console
 MY_DISCOVERY_DOMAIN          A        EXTERNAL-IP for spire-oidc service
@@ -112,7 +117,7 @@ oidc-discovery.example.org   A        93.184.216.34
 ```
 
 {{< info >}}
-Do not use the oidc-discovery.example.org domain or IP address shown above.
+Do not use the `oidc-discovery.example.org` domain or IP address shown above.
 {{< /info >}}
 
 ## Verify the DNS A Record
@@ -133,7 +138,7 @@ As with any change to DNS, it will take minutes or hours for the new A record to
 
    The `Address:` field at the bottom should correspond to the IP address in the A record.
 
-2. In your browser, navigate to https://MY_DISCOVERY_DOMAIN/.well-known/openid-configuration . You should see JSON output similar to the following:
+2. In your browser, navigate to `https://MY_DISCOVERY_DOMAIN/.well-known/openid-configuration`. You should see JSON output similar to the following:
 
    ```json
    {
@@ -293,7 +298,7 @@ To allow the workload from outside AWS to access AWS S3, add the workload's SPIF
    ```json
    "MY_DISCOVERY_DOMAIN:sub": "spiffe://example.org/ns/default/sa/default"
    ```
-   But substitute your Discovery document FQDN for MY\_DISCOVERY\_DOMAIN. Add a comma at the end of the previous line after `"mys3"`. When finished, the JSON should look similar to the following if you used oidc-discovery.example.org for your OIDC discovery domain:
+   But substitute your Discovery document FQDN for MY\_DISCOVERY\_DOMAIN. Add a comma at the end of the previous line after `"mys3"`. When finished, the JSON should look similar to the following if you used `oidc-discovery.example.org` for your OIDC discovery domain:
 
    ```json
    {

--- a/content/spire/try/oidc-federation-aws.md
+++ b/content/spire/try/oidc-federation-aws.md
@@ -1,6 +1,6 @@
 ---
 title: AWS OIDC Authentication
-description: Using OIDC to Authenticate SPIRE to AWS S3 on Kubernetes
+description: Using SPIRE and OIDC to Authenticate Workloads on Kubernetes to AWS S3
 weight: 4
 toc: true
 aliases:
@@ -15,7 +15,7 @@ This tutorial builds on the [Kubernetes Quickstart](/spire/try/getting-started-k
 In this tutorial you will learn how to:
 
 * Deploy the OIDC Discovery Provider Service
-* Create the required DNS A record to point to the Discovery Provider document
+* Create the required DNS A record to point to the OIDC Discovery document endpoint
 * Create a sample AWS identity provider, policy, role, and S3 bucket
 * Test access to the S3 bucket
 
@@ -24,36 +24,14 @@ In this tutorial you will learn how to:
 Note the following required accounts, prerequisites, and limitations before starting this tutorial:
 
 * You'll need access to the Kubernetes environment that you configured when going through [Kubernetes Quickstart](/spire/try/getting-started-k8s/) 
-* You'll need access to the AWS console to configure an identity provider, policy, role, and S3 bucket
+* You'll need access to the AWS console with an account that has permissions to configure an identity provider, IAM policy, IAM role, and S3 bucket
 * This tutorial cannot run on Minikube as the Kubernetes environment must be network accessible by AWS
-* You'll need the ability to configure a DNS A record for the SPIRE OIDC Discovery Provider document location (see next section)
+* You'll need the ability to configure a DNS A record for the SPIRE OIDC Discovery document endpoint (see [Part 2](#part-2-configure-dns-for-the-oidc-discovery-provider-ip-address))
 
-### Required DNS A Record for the OIDC Discovery Provider IP Address
 
-The SPIRE OIDC Discovery Provider provides a URL to the location of the discovery document specified by the OIDC protocol. After starting the spire-oidc service you'll need to configure a DNS A record to point to the external IP address of that service. In the YAML files set up for this tutorial, replace MY\_DISCOVERY\_DOMAIN with the FQDN of the planned DNS hostname. The FQDN value for MY\_DISCOVERY\_DOMAIN does not need to correspond to an existing domain on your network. It is specific to the Kubernetes environment.
+# Part 1: Configure SPIRE Components
 
-To get the external IP address required for the A record, you will need to proceed through the steps in this tutorial until you start the spire-oidc service and verify the external IP address in the section [Verify That spire-oidc has an External Service Address](#verify-that-spireoidc-has-an-external-service-address). The DNS A record should take the following form:
-
-```console
-MY_DISCOVERY_DOMAIN          A        EXTERNAL-IP for spire-oidc service
-```
-
-For example:
-```console
-oidc-discovery.example.org   A        93.184.216.34
-```
-
-{{< info >}}
-As with any change to DNS, it will take minutes or hours for the new A record to propagate to DNS servers. This tutorial will not work until the A record is propagated. Once the A record is propagated, you should be able to view the discovery document at https://MY_DISCOVERY_DOMAIN/.well-known/openid-configuration .
-{{< /info >}}
-
-Although this tutorial should contain all the info you need, the SPIRE OIDC Discovery Provider configuration file format is described on [GitHub](https://github.com/spiffe/spire/tree/master/support/oidc-discovery-provider).
-
-This tutorial uses Let's Encrypt to configure a certificate for the OIDC Discovery Provider domain. But other than editing the oidc-dp-configmap.yaml file as described in the previous section, no additional setup steps are required for Let's Encrypt.
-
-# Part One: Configure SPIRE Components
-
-In the first part of this procedure, you configure the SPIRE components. In the second part, you configure the AWS components. You test the connection in the third part.
+In the first part of this procedure, you configure the SPIRE components in Kubernetes.
 
 ## Download Kubernetes YAML Files for this Tutorial
 
@@ -65,8 +43,8 @@ The following strings in the YAML files must be substituted for values specific 
 
 | String | Description | Files to Change |
 | --- | --- | --- |
-| MY\_EMAIL\_ADDRESS | The terms of service for the Let's Encrypt certificate authority requires that you specify a valid email. Let's Encrypt is used to configure a certificate for the OIDC Discovery Domain (see the [Discovery Provider](#required-dns-a-record-for-the-oidc-discovery-provider-ip-address) info above). Example value: user@example.org | oidc-dp-configmap.yaml (1 instance) |
-| MY\_DISCOVERY\_DOMAIN | You must configure a public DNS A record for the IP address of the OIDC Discovery Provider. See the next section for details. Example value: `oidc-discovery.example.org` | ingress.yaml (2 instances), oidc-dp-configmap.yaml (1 instance), server-configmap.yaml (1 instance) |
+| MY\_EMAIL\_ADDRESS | Specify a valid email address to satisfy the terms of service for the Let's Encrypt certificate authority used in AWS OIDC federation. No email will actually be sent to this address. Example value: user@example.org | oidc-dp-configmap.yaml (1 instance) |
+| MY\_DISCOVERY\_DOMAIN | Replace with the domain that you will use in the A record for the OIDC Discovery document endpoint. See [Part 2](#part-2-configure-dns-for-the-oidc-discovery-provider-ip-address) for details. Example value: `oidc-discovery.example.org` | ingress.yaml (2 instances), oidc-dp-configmap.yaml (1 instance), server-configmap.yaml (1 instance) |
 
 In the YAML files, instances of the `example.org` [trust domain](/spiffe/concepts/#trust-domain) are valid to use for this tutorial and do not need to be changed.
 
@@ -85,10 +63,12 @@ $ kubectl apply \
     -f server-statefulset.yaml
 ```
 
-To verify that the spire-server-0 pod has spire-server and spire-oidc containers, run:
+To verify that the spire-server pod has spire-server and spire-oidc containers, run:
 
 ```console
-$ kubectl get pods spire-server-0 -n spire -o jsonpath='{.spec.containers[*].name}{"\n"}'
+$ kubectl get pods -n spire -l app=spire-server -o \
+    jsonpath='{.items[*].spec.containers[*].name}{"\n"}'
+spire-server spire-oidc
 ```
 
 ## Configure the OIDC Discovery Provider Service and Ingress
@@ -101,48 +81,86 @@ $ kubectl apply \
     -f ingress.yaml 
 ```
 
-## Verify the spire-server Stateful Set
 
-Verify that the spire-server stateful set has been created:
+# Part 2: Configure DNS for the OIDC Discovery IP Address
 
-```console
-$ kubectl get statefulset --namespace spire
+As part of this tutorial, you will need to register a public DNS record that will resolve to the public IP address of your Kubernetes cluster. This will require you or an administrator to have registered a domain name (e.g. yutani.com) with a domain name registrar, have configured its name server to point to a DNS service, and to be able to create an A record for a new subdomain (e.g. oidc-discovery.yutani.com) in that DNS service. If you don't have a registered domain name or access to a DNS service, services like Google Domains can help you set one up for a fee.
 
-NAME           READY   AGE
-spire-server   0/1     10h
-```
+In this tutorial, the subdomain that you create will provide an endpoint to the discovery document specified by the OIDC protocol. AWS will query this endpoint as part of the authentication handshake between AWS and SPIRE.
 
-## Verify That spire-oidc has an External Service Address
+## Display the External Service Address of spire-oidc
 
-Run the following command to verify that the EXTERNAL-IP value is present for the spire-oidc service. The spire-oidc Discovery Provider service must provide an external IP address for AWS to access the OIDC discovery document provided by spire-oidc.
+Run the following command to display the external IP address of the spire-oidc service. The spire-oidc Discovery Provider service must provide an external IP address for AWS to access the OIDC Discovery document provided by spire-oidc.
 
 ```console
-$ kubectl get service -n spire
+$ kubectl get service -n spire spire-oidc
 
 NAME           TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)          AGE
 spire-oidc     LoadBalancer   10.12.0.18    34.82.139.13   443:30198/TCP    108s
-spire-server   NodePort       10.12.13.51   <none>         8081:32115/TCP   10h
 ```
 
-### Configure a DNS A Record to Point to the spire-oidc EXTERNAL-IP
+## Configure an A Record for the OIDC Discovery Document Endpoint
 
-At this point you can put the value of the spire-oidc EXTERNAL-IP in the required DNS A record, along with the value of the MY\_DISCOVERY\_DOMAIN domain that you specified in oidc-dp-configmap.yaml. For more details, see [Required DNS A Record for the OIDC Discovery Provider IP Address](#required-dns-a-record-for-the-oidc-discovery-provider-ip-address).
-
-## Deploy the Client
-
-Apply the client deployment file to create a client in a different namespace that you will use for testing in [part 3](#part-3-test-access-to-aws-s3) of this document:
+Using your preferred DNS tool, put the MY\_DISCOVERY\_DOMAIN domain and the spire-oidc external IP address in a new DNS A record. The A record should take the following form:
 
 ```console
-$ kubectl apply -f client-deployment.yaml
+MY_DISCOVERY_DOMAIN          A        EXTERNAL-IP for spire-oidc service
 ```
 
-# Part Two: Configure AWS Components
+For example:
+```console
+oidc-discovery.example.org   A        93.184.216.34
+```
+
+{{< info >}}
+Do not use the oidc-discovery.example.org domain or IP address shown above.
+{{< /info >}}
+
+## Verify the DNS A Record
+
+As with any change to DNS, it will take minutes or hours for the new A record to propagate to DNS servers. This tutorial will not work until the A record is propagated. Negative DNS query results will be cached, causing headaches. So, to be safe, wait an hour or so to test the DNS change after creating the A record.
+
+1. Use `nslookup` to display the DNS information for the domain you configured in the A record:
+
+   ```console
+   $ nslookup oidc-discovery.example.org
+   Server:        203.0.113.0
+   Address:	      203.0.113.0#53
+
+   Non-authoritative answer:
+   Name:	oidc-discovery.example.org
+   Address: 93.184.216.34
+   ```
+
+   The `Address:` field at the bottom should correspond to the IP address in the A record.
+
+2. In your browser, navigate to https://MY_DISCOVERY_DOMAIN/.well-known/openid-configuration . You should see JSON output similar to the following:
+
+   ```json
+   {
+     "issuer": "https://oidc-discovery.example.org",
+     "jwks_uri": "https://oidc-discovery.example.org/keys",
+     "authorization_endpoint": "",
+     "response_types_supported": [
+       "id_token"
+     ],
+     "subject_types_supported": [],
+     "id_token_signing_alg_values_supported": [
+       "RS256",
+       "ES256",
+       "ES384"
+     ]
+   }
+   ```
+
+
+# Part 3: Configure AWS Components
 
 After configuring the SPIRE components, continue with configuring AWS.
 
 ## Set up an OIDC Identity Provider on AWS
 
-To allow the SPIRE Agent to authenticate to an AWS service S3 bucket, you must configure an OpenID Connect identity provider. The AWS identity provider queries the SPIRE OIDC Discovery Provider that you configured.
+To allow the SPIRE Agent to authenticate to an AWS service S3 bucket, you must configure an OpenID Connect identity provider. The AWS identity provider queries the SPIRE OIDC Discovery document endpoint that you configured.
 
 1. Navigate to the AWS [Identity and Access Management (IAM) page](https://console.aws.amazon.com/iam/home#/home), logging in if necessary.
 
@@ -150,9 +168,9 @@ To allow the SPIRE Agent to authenticate to an AWS service S3 bucket, you must c
 
 3. For **Provider Type**, choose **OpenID Connect**.
 
-4. For **Provider URL**, type `https://` and then the FQDN corresponding to the value that you used for MY\_DISCOVERY\_DOMAIN in the YAML files. The AWS identity provider queries the SPIRE OIDC Discovery Provider at this URL.
+4. For **Provider URL**, type `https://` and then the FQDN corresponding to the value that you used for MY\_DISCOVERY\_DOMAIN in the YAML files. The AWS identity provider queries the SPIRE OIDC Discovery document at this URL.
 
-5. For **Audience**, type `mys3`. The SPIRE Agent presents this string to AWS when authenticating to the Amazon S3 bucket. Click **Next Step**. AWS verifies access to the Provider URL after you click the button and displays an error if it is inaccessible. If this occurs, ensure that the DNS is properly configured for public access to the SPIRE OIDC Discovery Provider (Provider URL).
+5. For **Audience**, type `mys3`. The SPIRE Agent presents this string to AWS when authenticating to the Amazon S3 bucket. Click **Next Step**. AWS verifies access to the Provider URL after you click the button and displays an error if it is inaccessible. If this occurs, ensure that the DNS is properly configured for public access to the SPIRE OIDC Discovery document endpoint (Provider URL).
 
 6. Verify the information on the **Verify Provider Information** page and if OK, click **Create**.
 
@@ -215,7 +233,7 @@ The IAM role contains the connection parameters for the OIDC federation to AWS s
 
 3. Click **Web Identity** near the top of the page.
 
-4. For **Identity provider**, choose the identity provider that you created in AWS. The identity provider will be your Discovery Provider FQDN followed by `:aud`, such as `oidc-discovery.example.org:aud`.
+4. For **Identity provider**, choose the identity provider that you created in AWS. The identity provider will be your Discovery document FQDN followed by `:aud`, such as `oidc-discovery.example.org:aud`.
 
 5. For **Audience**, choose the audience you specified in the identity provider: `mys3`.
 
@@ -235,14 +253,16 @@ To allow the workload from outside AWS to access AWS S3, add the workload's SPIF
 
 2. Click **Roles** on the left, use the search field to find the `oidc-federation-test-role` IAM role that you created in the last section, and click the role.
 
-3. Click the **Trust relationships** tab near the middle of the page and then click **Edit trust relationship**.
+3. At the top of the **Summary** page, next to **Role ARN**, copy the role ARN into the clipboard by clicking the small icon at the end. Save the ARN in a file such as `oidc-arn.txt` for use in the testing section ([Part 4](#part-4-test-access-to-aws-s3)).
 
-4. In the JSON access control policy, add a condition line at the end of the `StringEquals` attribute to restrict access to workloads matching the workload SPIFFE ID that was assigned in the [Kubernetes Quickstart](/spire/try/getting-started-k8s/). The new line to add is:
+4. Click the **Trust relationships** tab near the middle of the page and then click **Edit trust relationship**.
+
+5. In the JSON access control policy, add a condition line at the end of the `StringEquals` attribute to restrict access to workloads matching the workload SPIFFE ID that was assigned in the [Kubernetes Quickstart](/spire/try/getting-started-k8s/). The new line to add is:
 
    ```json
    "MY_DISCOVERY_DOMAIN:sub": "spiffe://example.org/ns/default/sa/default"
    ```
-   But substitute your Discovery Provider FQDN for MY\_DISCOVERY\_DOMAIN. Add a comma at the end of the previous line after `"mys3"`. When finished, the JSON should look similar to:
+   But substitute your Discovery document FQDN for MY\_DISCOVERY\_DOMAIN. Add a comma at the end of the previous line after `"mys3"`. When finished, the JSON should look similar to the following if you used oidc-discovery.example.org for your OIDC discovery domain:
 
    ```json
    {
@@ -251,13 +271,13 @@ To allow the workload from outside AWS to access AWS S3, add the workload's SPIF
        {
          "Effect": "Allow",
          "Principal": {
-           "Federated": "arn:aws:iam::012345678901:oidc-provider/MY_DISCOVERY_DOMAIN"
+           "Federated": "arn:aws:iam::012345678901:oidc-provider/oidc-discovery.example.org"
          },
          "Action": "sts:AssumeRoleWithWebIdentity",
          "Condition": {
            "StringEquals": {
-             "MY_DISCOVERY_DOMAIN:aud": "mys3",
-             "MY_DISCOVERY_DOMAIN:sub": "spiffe://example.org/ns/default/sa/default"
+             "oidc-discovery.example.org:aud": "mys3",
+             "oidc-discovery.example.org:sub": "spiffe://example.org/ns/default/sa/default"
            }
          }
        }
@@ -265,9 +285,9 @@ To allow the workload from outside AWS to access AWS S3, add the workload's SPIF
    }
    ```
 
-5. Click **Update Trust Policy**. This change to the IAM role takes a minute or two to propagate.
+6. Click **Update Trust Policy**. This change to the IAM role takes a minute or two to propagate.
 
-## Create an AWS S3 Test File
+## Create an AWS S3 Bucket and Test File
 
 Create a simple test file in an AWS S3 bucket to use for testing.
 
@@ -295,40 +315,54 @@ Create a simple test file in an AWS S3 bucket to use for testing.
 
 9. Click **Upload**.
 
-# Part Three: Test Access to AWS S3
+
+# Part 4: Test Access to AWS S3
 
 Now that Kubernetes and AWS are configured for OIDC federation, we'll test the connection. This test retrieves a JWT SVID from the SPIRE Agent and uses the JWT token in the JWT SVID to access S3.
 
-1. Run the following command to list the full name of the client pod:
-   ```console
-   $ kubectl get pods
+1. In the directory containing the YAML files, apply the client deployment file to create a test client in a different namespace:
 
-   NAME                      READY   STATUS    RESTARTS   AGE
-   client-74d4467b44-7nrs2   1/1     Running   0          27s
-   ```
+    ```console
+    $ kubectl apply -f client-deployment.yaml
+    ```
 
-2. Start a shell on the client using the client pod name shown under **NAME** in the output of the last step.
+2. Start a shell on the client:
 
    ```console
-   $ kubectl exec -it client-74d4467b44-7nrs2 /bin/sh
+   $ kubectl exec -it $(kubectl get pods -o \
+       jsonpath={'.items[*]'.metadata.name}) /bin/sh
    ```
 
 3. Fetch a JWT SVID from the identity provider on AWS and save the token from the JWT SVID into a file on the client container called `token`:
 
    ```console
-   # /opt/spire/bin/spire-agent api fetch jwt -audience mys3 -socketPath /run/spire/sockets/agent.sock | sed '2!d' | sed 's/[[:space:]]//g' > token
+   # /opt/spire/bin/spire-agent api fetch jwt -audience mys3 -socketPath \
+       /run/spire/sockets/agent.sock | sed '2!d' | sed 's/[[:space:]]//g' > token
    ```
 
-4. Navigate to the AWS [Identity and Access Management (IAM) page](https://console.aws.amazon.com/iam/home#/home), logging in if necessary.
-
-5. Click **Roles**, search for the `oidc-federation-test-role` role you created, and click on the role name.
-
-6. At the top of the **Summary** page, next to **Role ARN**, copy the role ARN into the clipboard by clicking the small icon at the end.
-
-7. Run the following command, pasting the ARN in place of ROLE-NAME-ARN:
+4. Verify that the token was successfully written:
 
    ```console
-   # AWS_ROLE_ARN=ROLE-NAME-ARN AWS_WEB_IDENTITY_TOKEN_FILE=token aws s3 cp s3://oidc-federation-test-bucket/test.txt test.txt
+   # cat token
+   eyJhbGciOiJSUzI1NiIsImtpZCI6InpRdm9WWVpoVTBJWlpEUXBVOFN0MFdoQXdWZVp1S2
+   JqIiwidHlwIjoiSldUIn0.eyJhdWQiOlsibXlzMyJdLCJleHAiOjE1ODU2MDYzNjAsImlh
+   dCI6MTU4NTYwNjA2MCwiaXNzIjoiaHR0cHM6Ly90ZWNocHVicy1vaWRjLWRpc2NvdmVyeS
+   5za2l0YWxlZS5vcmciLCJzdWIiOiJzcGlmZmU6Ly9leGFtcGxlLm9yZy9ucy9kZWZhdWx0
+   L3NhL2RlZmF1bHQifQ.aGyDeySJ1BFeM9Afv3Vi6BBE3fw-Op4JWWuq3IfzRp9NW4Aet_Z
+   SkAG25O7A0C8MZgFb2_-1o0O60HMhO0CUPoJzIScUL62GarfOE3-HDKZbf3fyh8dzO14wq
+   oU9JAEbCZuMViyW0uMFqAOMYXcGFSEyA0DKcYrHQxT7t9kUTW6BiPtM5s5AZG0uOeUGBeH
+   hh2q1FAi97Ui3vNdH4nmSaklhtKzQh18j5HA4fSXOIwYIIlUm9b6nQlxTKNrS93uD8TSj7
+   oiZbiGU0w2YetmSrQi15mqPUshnuigNCAFeHgB-eoSK9zAPJncWmZqyD8RLbU7LT61LusF
+   g-JsJaiVYkA
+   ```
+
+5. Locate the ARN of the IAM role that you created in [Part 3](#part-3-configure-aws-components) and saved in `oidc-arn.txt`. Alternatively, return to the AWS console and find the ARN of the IAM role there.
+
+6. Run the following command, pasting the ARN in place of ROLE-NAME-ARN:
+
+   ```console
+   # AWS_ROLE_ARN=ROLE-NAME-ARN AWS_WEB_IDENTITY_TOKEN_FILE=token aws s3 \
+       cp s3://oidc-federation-test-bucket/test.txt test.txt
    ```
 
    If successful, this command will output the following and the `test.txt` file should be copied to the client container:
@@ -339,14 +373,14 @@ Now that Kubernetes and AWS are configured for OIDC federation, we'll test the c
 
    See the next section if the command isn't successful.
 
-8. Verify that the `test.txt` exists and contains `oidc-tutorial file`:
+7. Verify that the `test.txt` exists and contains `oidc-tutorial file`:
 
    ```console
    # cat test.txt
    oidc-tutorial file
    ```
 
-9. Exit from `/bin/sh` on the client container:
+8. Exit from `/bin/sh` on the client container:
 
    ```console
    # exit
@@ -412,4 +446,4 @@ Delete the policy, role, and S3 bucket that you configured for this tutorial.
 
 ## DNS Cleanup
 
-Remove the A record that you configured for the SPIRE OIDC Discovery Provider document location.
+Remove the A record that you configured for the SPIRE OIDC Discovery document endpoint.

--- a/content/spire/try/spire+aws-oidc-federation.md
+++ b/content/spire/try/spire+aws-oidc-federation.md
@@ -1,0 +1,360 @@
+---
+title: AWS OIDC Authentication
+description: Using OIDC to Authenticate SPIRE to AWS S3
+weight: 3
+toc: true
+aliases:
+menu:
+  spire:
+    weight: 50
+    parent: 'spire-try'
+---
+
+This tutorial builds on the [Kubernetes Quickstart](/spire/try/getting-started-k8s/) guide to describe how a SPIRE identified workload can, using a JWT-SVID, authenticate to Amazon AWS APIs, assume an AWS IAM role, and retrieve data from an AWS S3 bucket. This avoids the need to create and deploy AWS IAM credentials with the workload itself.
+
+## Prerequisites
+
+Note the following required accounts, prerequisites, and limitations before starting on this tutorial:
+
+* Access to the Kubernetes environment that you configured when going through [Kubernetes Quickstart](/spire/try/getting-started-k8s/) 
+* This tutorial cannot run on Minikube as the Kubernetes environment must be network accessible by AWS
+* Access to the AWS console
+* [AWS CLI tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) installed on the same instance as the SPIRE Agent
+* DNS A record or CNAME for the SPIRE OIDC Discovery Provider REST API
+
+# Part One: Configure SPIRE Components
+
+In the first part of this procedure, you configure the SPIRE components. In the second part, you configure the AWS components. You test the connection in the third part.
+
+## Download Kubernetes YAML Files for this Tutorial
+
+Completing this tutorial requires a number of YAML files. To get these files, clone https://github.com/spiffe/spire-tutorials. The files for this tutorial are in the k8s/REPLACE_ME directory.
+
+## Replace Placeholder Strings in YAML Files
+
+The following strings in the YAML files must be substituted for values specific to your environment. Each location where you must make a change has been marked with `TODO:` in the YAML files.
+
+| String | Example Substitution | Description | Files to Change |
+| --- | --- | --- | --- |
+
+| MY\_EMAIL\_ADDRESS | `user@example.org` | The terms of service for the Let's Encrypt certificate authority requires that you specify a valid email | oidc-dp-configmap.yaml |
+| MY\_DISCOVERY\_DOMAIN | `host1.example.org` | You must configure a public DNS A record for the OIDC Discovery Provider REST API. See the next section for details | server-configmap.yaml (1 instance), oidc-dp-configmap.yaml (1 instance), ingress.yaml (2 instances) |
+
+In the YAML files, instances of the `example.org` trust domain are valid to use for this tutorial and do not need to be changed.
+
+## Configure DNS for the OIDC Discovery Provider REST API
+
+SPIRE OIDC Discovery Provider provides a REST API to serve OIDC discovery documents. Configure DNS to make the domain hosting the OIDC Discovery Provider publicly resolvable, such as by an A record or CNAME. In the YAML files set up for this tutorial, replace MY\_DISCOVERY\_DOMAIN with the FQDN of the DNS hostname that you create.
+
+## Create OIDC Discovery Provider Configmap
+
+The SPIRE OIDC Discovery Provider serves OIDC discovery documents via a REST API at the FQDN that you configured. The oidc-dp-configmap.yaml file specifies the URL to the OIDC Discovery Provider.
+
+Before running the command below, ensure that you have replaced the MY\_DISCOVERY\_DOMAIN placeholder with the FQDN of the Discovery Provider that you configured in DNS as described in [Replace Placeholder Strings in YAML Files](#replace-placeholder-strings-in-yaml-files).
+
+Use the following command to apply the updated server configmap, the configmap for the OIDC Discovery Provider, and deploy the statefulset:
+
+```
+$ kubectl apply \
+    -f server-configmap.yaml \
+    -f oidc-dp-configmap.yaml \
+    -f server-statefulset.yaml
+```
+
+This creates a stateful set called **spire-server**.
+
+## Configure the OIDC Discovery Provider Service and Ingress
+
+Use the following command to set up a service definition for the OIDC Discovery Provider and to configure ingress for that service:
+
+```
+$ kubectl apply \
+    -f server-oidc-service.yaml \
+    -f ingress.yaml 
+ ```
+
+## Verify the spire-server Stateful Set
+
+Verify that the spire-server stateful set has been created:
+
+```
+$ kubectl get statefulset --namespace spire
+
+NAME           READY   AGE
+spire-server   0/1     10h
+```
+
+## Verify That spire-oidc has an External Service Address
+
+Run the following command to verify that the EXTERNAL-IP value is present for the spire-oidc service. The spire-oidc Discovery Provider service must provide an external IP address for AWS to access the REST API provided by spire-oidc.
+
+```
+$ kubectl get service -n spire
+
+NAME           TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)          AGE
+spire-oidc     LoadBalancer   10.12.0.18    34.82.139.13   443:30198/TCP    108s
+spire-server   NodePort       10.12.13.51   <none>         8081:32115/TCP   10h
+```
+
+## Create Client
+
+Apply the deployment file:
+
+```
+$ kubectl apply -f client-deployment.yaml
+```
+
+
+
+
+## Test AWS
+
+### Connect client
+
+Get:
+$ kubectl get pods 
+
+output:
+```
+$ kubectl get pods
+NAME                      READY   STATUS    RESTARTS   AGE
+client-74d4467b44-7nrs2   1/1     Running   0          27s
+```
+
+Go into:
+```
+$ kubectl exec -it client-74d4467b44-7nrs2 /bin/sh
+```
+
+### Get token
+I will fetch for an jwt svid and create a `token` file that includes only token from it.
+**replace `mys3` with your Authentication provider audience**
+```
+$ /opt/spire/bin/spire-agent api fetch jwt -audience mys3 -socketPath /run/spire/sockets/agent.sock | sed '2q' | sed 's/[[:space:]]//g' > token
+```
+
+### Access to aws
+It will connect to aws s3 using token from fetched svid
+***
+replace:
+- `${ROLE-NAME-ARN}` with your role arn on aws
+- `s3://oidc-federation-test/test.txt test.txt` replace with your configured s3 bucket
+***
+
+```
+$ AWS_ROLE_ARN=${ROLE-NAME-ARN} AWS_WEB_IDENTITY_TOKEN_FILE=token aws s3 cp s3://oidc-tutorial-bucket/test.txt test.txtt
+```
+
+## Clean
+
+### Delete client namespace
+```
+$ kubectl delete deployment client
+```
+
+### Delete spire namespace
+```
+$ kubectl delete namespace spire
+```
+
+
+
+
+
+
+======================================================================
+======================================================================
+# Part Two: Configure AWS Components
+
+After configuring the SPIRE components, continue with configuring AWS.
+
+## Set up an OIDC Identity Provider on AWS
+
+To allow the SPIRE Agent to authenticate to an AWS service S3 bucket, you must configure an OpenID Connect identity provider. The AWS identity provider queries the SPIRE OIDC Discovery Provider REST API that you configured.
+
+1. Navigate to the AWS [Identity and Access Management (IAM) page](https://console.aws.amazon.com/iam/home#/home), logging in if necessary.
+
+2. Click **Identity Providers** on the left and then click **Create Provider** at the top of the page.
+
+3. For **Provider Type**, choose **OpenID Connect**.
+
+4. For **Provider URL**, type `https://` and then the FQDN corresponding to the value that you used for MY\_DISCOVERY\_DOMAIN in the YAML files. The AWS identity provider queries the SPIRE OIDC Discovery Provider REST API at this URL.
+
+5. For **Audience**, type `mys3`. The SPIRE Agent presents this string to AWS when authenticating to the Amazon S3 bucket. Click **Next Step**. AWS verifies access to the Provider URL after you click the button and displays an error if it is inaccessible. If this occurs, ensure that the DNS is properly configured for public access to the SPIRE OIDC Discovery Provider REST API (Provider URL).
+
+6. Verify the information on the **Verify Provider Information** page and if OK, click **Create**.
+
+## Create an AWS IAM Policy
+
+Create the following simple AWS IAM policy that governs access to the S3 bucket used in this tutorial. In the next section, you will associate this policy with an IAM role.
+
+1. Navigate to the AWS [Identity and Access Management (IAM) page](https://console.aws.amazon.com/iam/home#/home), logging in if necessary.
+
+2. Click **Policies** on the left and then click **Create Policy** in the middle of the page.
+
+3. Click the **JSON** tab at the top.
+
+4. Replace the existing skeleton JSON blob with the following JSON blob:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutAccountPublicAccessBlock",
+                "s3:GetAccountPublicAccessBlock",
+                "s3:ListAllMyBuckets",
+                "s3:ListJobs",
+                "s3:CreateJob",
+                "s3:HeadBucket"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": [
+                "arn:aws:s3:::oidc-federation-test",
+                "arn:aws:s3:::oidc-federation-test/*",
+                "arn:aws:s3:*:*:job/*"
+            ]
+        }
+    ]
+}
+```
+
+5. Click **Review policy**.
+
+6. For **Name**, type a name such as `oidc-federation-test-policy`.
+
+7. Optionally, type a **Description**.
+
+8. Click **Create policy**.
+
+## Create an AWS IAM Role for the Identity Provider
+
+The IAM role contains the connection parameters for the OIDC federation to AWS such as the OIDC identity provider, IAM policy, and SPIFFE ID of the connecting workloads.
+
+1. Navigate to the AWS [Identity and Access Management (IAM) page](https://console.aws.amazon.com/iam/home#/home), logging in if necessary.
+
+2. Click **Roles** on the left and then click **Create Role** in the middle of the page.
+
+3. Click **Web Identity** near the top of the page.
+
+4. For **Identity provider**, choose the identity provider that you created in AWS in the previous section.
+
+5. For **Audience**, choose the audience you specified in the identity provider: `mys3`.
+
+6. Click **Next: Permissions**.
+
+7. Search for the policy that you created in the previous section: `oidc-federation-test-policy`. Click the check box next to that policy and then click **Next: Tags**.
+
+8. Click **Next: Review** to skip the **Add Tags** screen.
+
+9. Type a name for the IAM role such as `oidc-federation-test-role`, a description if desired, and click **Create role**. 
+
+## Add the SPIFFE ID to the IAM Role
+
+To allow the workload from outside AWS to access AWS S3, add the workload's SPIFFE ID to the IAM role. This restricts access to the IAM role to JWT SVIDs with the specified SPIFFE ID.
+
+1. Navigate to the AWS [Identity and Access Management (IAM) page](https://console.aws.amazon.com/iam/home#/home), logging in if necessary.
+
+2. Open the IAM role that you created in the previous section, `oidc-federation-test-role`. If needed, click **Roles** on the left, use the search field to find the IAM role that you created in the last section, and click the role.
+
+3. Click the **Trust relationships** tab near the middle of the page and then click **Edit trust relationship**.
+
+4. In the JSON access control policy, add a condition line at the end of the `StringEquals` attribute to restrict access to workloads matching the workload SPIFFE ID that was assigned in the [Kubernetes Quickstart](/spire/try/getting-started-k8s/).
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::012345678901:oidc-provider/MY_DISCOVERY_DOMAIN"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "MY_DISCOVERY_DOMAIN:aud": "mys3",
+          "MY_DISCOVERY_DOMAIN:sub": "spiffe://example.org/ns/default/sa/default"
+        }
+      }
+    }
+  ]
+}
+```
+
+5. Click **Update Trust Policy**.
+
+## Create an AWS S3 Test File
+
+Create a simple test file in an AWS S3 bucket to use for testing.
+
+1. Create a text file on your local computer called 'test.txt` with the following single line:
+```
+oidc-tutorial file
+```
+You'll upload this file to the S3 bucket later.
+
+2. Navigate to the AWS [Amazon S3 page](https://s3.console.aws.amazon.com/s3/home) logging in if necessary.
+
+3. Click **Create bucket**.
+
+4. Under **Bucket name** type `oidc-federation-test-bucket`.
+
+5. Leave the **Region**, **Bucket settings for Block Public Access**, and **Advanced settings** at the default values and click **Create bucket**.
+
+6. Click `oidc-federation-test-bucket` to open the bucket. 
+
+7. Click **Upload**.
+
+8. Add the `test.txt` file to the upload area using your local file navigator or drag and drop.
+
+9. Click **Upload**.
+
+# Part 3: Test Access to AWS S3
+
+Now that Kubernetes and AWS are configured for OIDC federation, we'll test the connection. This test retrieves a JWT SVID from the SPIRE Agent and uses the JWT token in the JWT SVID to access S3.
+
+1. Run: 
+```console
+$ kubectl get pods
+
+NAME                      READY   STATUS    RESTARTS   AGE
+client-74d4467b44-7nrs2   1/1     Running   0          27s
+```
+
+2. Start a shell on the client using the client pod name just shown.
+
+```console
+$ kubectl exec -it client-74d4467b44-7nrs2 /bin/sh
+```
+
+3. Fetch a JWT SVID from the identity provider on AWS and save the token from the JWT SVID into a file called `token`:
+
+```console
+/opt/spire/bin/spire-agent api fetch jwt -audience mys3 -socketPath /run/spire/sockets/agent.sock | sed '2q' | sed 's/[[:space:]]//g' > token
+```
+
+4. Navigate to the AWS [Identity and Access Management (IAM) page](https://console.aws.amazon.com/iam/home#/home), logging in if necessary.
+
+5. Click **Roles**, search for the role you just created, and click on the role name.
+
+6. At the top of the **Summary** page, copy the role ARN into the clipboard.
+
+7. Run the following command, pasting the ARN in place of ROLE-NAME-ARN:
+```console
+AWS_ROLE_ARN=ROLE-NAME-ARN AWS_WEB_IDENTITY_TOKEN_FILE=token aws s3 cp s3://oidc-federation-test-bucket/test.txt test.txt
+```
+
+If successful, this command would output:
+
+```console
+download: s3://oidc-federation-test-bucket/test.txt to ./test.txt
+```

--- a/content/spire/try/spire+aws-oidc-federation.md
+++ b/content/spire/try/spire+aws-oidc-federation.md
@@ -19,7 +19,6 @@ Note the following required accounts, prerequisites, and limitations before star
 * Access to the Kubernetes environment that you configured when going through [Kubernetes Quickstart](/spire/try/getting-started-k8s/) 
 * This tutorial cannot run on Minikube as the Kubernetes environment must be network accessible by AWS
 * Access to the AWS console
-* [AWS CLI tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) installed on the same instance as the SPIRE Agent
 * DNS A record or CNAME for the SPIRE OIDC Discovery Provider REST API
 
 # Part One: Configure SPIRE Components
@@ -43,7 +42,7 @@ In the YAML files, instances of the `example.org` trust domain are valid to use 
 
 ## Configure DNS for the OIDC Discovery Provider REST API
 
-SPIRE OIDC Discovery Provider provides a REST API to serve OIDC discovery documents. Configure DNS to make the domain hosting the OIDC Discovery Provider publicly resolvable, such as by an A record or CNAME. In the YAML files set up for this tutorial, replace MY\_DISCOVERY\_DOMAIN with the FQDN of the DNS hostname that you create.
+SPIRE OIDC Discovery Provider provides a REST API to serve OIDC discovery documents. Configure DNS to make the domain hosting the OIDC Discovery Provider publicly resolvable, such as by an A record or CNAME. In the YAML files set up for this tutorial, replace MY\_DISCOVERY\_DOMAIN with the FQDN of the DNS hostname that you create. Although this page should contain all the info you need to run this tutorial, the OIDC Discovery Provider configuration file format is described on [GitHub](https://github.com/spiffe/spire/tree/master/support/oidc-discovery-provider).
 
 ## Create OIDC Discovery Provider Configmap
 
@@ -51,22 +50,26 @@ The SPIRE OIDC Discovery Provider serves OIDC discovery documents via a REST API
 
 Before running the command below, ensure that you have replaced the MY\_DISCOVERY\_DOMAIN placeholder with the FQDN of the Discovery Provider that you configured in DNS as described in [Replace Placeholder Strings in YAML Files](#replace-placeholder-strings-in-yaml-files).
 
-Use the following command to apply the updated server configmap, the configmap for the OIDC Discovery Provider, and deploy the statefulset:
+Use the following command to apply the updated server configmap, the configmap for the OIDC Discovery Provider, and deploy the updated **spire-server** statefulset:
 
-```
+```console
 $ kubectl apply \
     -f server-configmap.yaml \
     -f oidc-dp-configmap.yaml \
     -f server-statefulset.yaml
 ```
 
-This creates a stateful set called **spire-server**.
+To verify that the spire-server-0 pod has spire-server and spire-oidc containers, run:
+
+```console
+kubectl get pods spire-server-0 -n spire -o jsonpath='{.spec.containers[*].name}'
+```
 
 ## Configure the OIDC Discovery Provider Service and Ingress
 
 Use the following command to set up a service definition for the OIDC Discovery Provider and to configure ingress for that service:
 
-```
+```console
 $ kubectl apply \
     -f server-oidc-service.yaml \
     -f ingress.yaml 

--- a/content/spire/try/spire+aws-oidc-federation.md
+++ b/content/spire/try/spire+aws-oidc-federation.md
@@ -36,7 +36,6 @@ The following strings in the YAML files must be substituted for values specific 
 
 | String | Example Substitution | Description | Files to Change |
 | --- | --- | --- | --- |
-
 | MY\_EMAIL\_ADDRESS | `user@example.org` | The terms of service for the Let's Encrypt certificate authority requires that you specify a valid email | oidc-dp-configmap.yaml |
 | MY\_DISCOVERY\_DOMAIN | `host1.example.org` | You must configure a public DNS A record for the OIDC Discovery Provider REST API. See the next section for details | server-configmap.yaml (1 instance), oidc-dp-configmap.yaml (1 instance), ingress.yaml (2 instances) |
 

--- a/content/spire/try/spire+aws-oidc-federation.md
+++ b/content/spire/try/spire+aws-oidc-federation.md
@@ -351,4 +351,3 @@ Delete the policy, role, and S3 bucket that you configured for this tutorial.
 Remove the DNS A Record for the SPIRE OIDC Discovery Provider
 
 You can remove the A record that you configured for the SPIRE OIDC Discovery Provider document location using your preferred DNS tool.
-

--- a/content/spire/try/spire+aws-oidc-federation.md
+++ b/content/spire/try/spire+aws-oidc-federation.md
@@ -320,15 +320,35 @@ If successful, this command would output the following and the test.txt file sho
 download: s3://oidc-federation-test-bucket/test.txt to ./test.txt
 ```
 
-## Cleanup
+# Cleanup
 
-### Delete client namespace
+When you are finished running this tutorial, you can use the following commands to remove the SPIRE setup for AWS OIDC Authentication.
+
+## Kubernetes Cleanup
+
+Keep in mind that these commands will also remove the setup that you configured in the [Kubernetes Quickstart](/spire/try/getting-started-k8s/).
+
+Delete the workload container:
+
 ```
 $ kubectl delete deployment client
 ```
 
-### Delete spire namespace
+Run the following command to delete all deployments and configurations for the agent, server, and namespace:
+
 ```
 $ kubectl delete namespace spire
 ```
+
+You may also need to remove configuration elements from your cloud-based Kubernetes environment.
+
+## AWS Cleanup
+
+Delete the policy, role, and S3 bucket that you configured for this tutorial.
+
+## DNS Cleanup
+
+Remove the DNS A Record for the SPIRE OIDC Discovery Provider
+
+You can remove the A record that you configured for the SPIRE OIDC Discovery Provider document location using your preferred DNS tool.
 

--- a/content/spire/try/spire+aws-oidc-federation.md
+++ b/content/spire/try/spire+aws-oidc-federation.md
@@ -130,7 +130,7 @@ At this point you can put the value of the spire-oidc EXTERNAL-IP in the require
 
 ## Deploy the Client
 
-Apply the client deployment file to create a client in a different namespace that you will use for testing in part 3 of this document:
+Apply the client deployment file to create a client in a different namespace that you will use for testing in [part 3](#part-3-test-access-to-aws-s3) of this document:
 
 ```console
 $ kubectl apply -f client-deployment.yaml
@@ -294,27 +294,27 @@ You'll upload this file to the S3 bucket later.
 
 Now that Kubernetes and AWS are configured for OIDC federation, we'll test the connection. This test retrieves a JWT SVID from the SPIRE Agent and uses the JWT token in the JWT SVID to access S3.
 
-1. Run: 
-```console
-$ kubectl get pods
+1. Run the following command to list the full name of the client pod:
+   ```console
+   $ kubectl get pods
 
-NAME                      READY   STATUS    RESTARTS   AGE
-client-74d4467b44-7nrs2   1/1     Running   0          27s
-```
+   NAME                      READY   STATUS    RESTARTS   AGE
+   client-74d4467b44-7nrs2   1/1     Running   0          27s
+   ```
 
-2. Start a shell on the client using the client pod name just shown.
+2. Start a shell on the client using the client pod name shown under **NAME** in the output of the last step.
 
-```console
-$ kubectl exec -it client-74d4467b44-7nrs2 /bin/sh
-```
+   ```console
+   $ kubectl exec -it client-74d4467b44-7nrs2 /bin/sh
+   ```
 
 3. Fetch a JWT SVID from the identity provider on AWS and save the token from the JWT SVID into a file on the client container called `token`:
 
-```console
-/opt/spire/bin/spire-agent api fetch jwt -audience mys3 -socketPath /run/spire/sockets/agent.sock | sed '2!d' | sed 's/[[:space:]]//g' > token
-```
+   ```console
+   /opt/spire/bin/spire-agent api fetch jwt -audience mys3 -socketPath /run/spire/sockets/agent.sock | sed '2!d' | sed 's/[[:space:]]//g' > token
+   ```
 
-To familiarize yourself with the form of the token 
+   To familiarize yourself with the form of the token, you may want to view it with the `cat` command.
 
 4. Navigate to the AWS [Identity and Access Management (IAM) page](https://console.aws.amazon.com/iam/home#/home), logging in if necessary.
 
@@ -323,20 +323,22 @@ To familiarize yourself with the form of the token
 6. At the top of the **Summary** page, copy the role ARN into the clipboard.
 
 7. Run the following command, pasting the ARN in place of ROLE-NAME-ARN:
-```console
-AWS_ROLE_ARN=ROLE-NAME-ARN AWS_WEB_IDENTITY_TOKEN_FILE=token aws s3 cp s3://oidc-federation-test-bucket/test.txt test.txt
-```
 
-If successful, this command would output the following and the `test.txt file` should copied to the client container:
+   ```console
+   AWS_ROLE_ARN=ROLE-NAME-ARN AWS_WEB_IDENTITY_TOKEN_FILE=token aws s3 cp s3://oidc-federation-test-bucket/test.txt test.txt
+   ```
 
-```console
-download: s3://oidc-federation-test-bucket/test.txt to ./test.txt
-```
+   If successful, this command will output the following and the `test.txt file` should be copied to the client container:
+
+   ```console
+   download: s3://oidc-federation-test-bucket/test.txt to ./test.txt
+   ```
 
 8. Exit from `/bin/sh` on the client container:
-```console
-exit
-```
+
+   ```console
+   exit
+   ```
 
 # Cleanup
 
@@ -346,17 +348,25 @@ When you are finished running this tutorial, you can use the following commands 
 
 Keep in mind that these commands will also remove the setup that you configured in the [Kubernetes Quickstart](/spire/try/getting-started-k8s/).
 
-Delete the workload container:
+1. Delete the workload container:
 
-```console
-$ kubectl delete deployment client
-```
+   ```console
+   $ kubectl delete deployment client
+   ```
 
-Run the following command to delete all deployments and configurations for the agent, server, and namespace:
+2. Delete all deployments and configurations for the agent, server, and namespace:
 
-```console
-$ kubectl delete namespace spire
-```
+   ```console
+   $ kubectl delete namespace spire
+   ```
+
+3. Delete the ClusterRole and ClusterRoleBinding settings:
+
+   ```console
+   $ kubectl delete clusterrole spire-server-trust-role spire-agent-cluster-role
+   $ kubectl delete clusterrolebinding spire-server-trust-role-binding spire-agent-cluster-role-binding
+   ```
+
 
 You may also need to remove configuration elements from your cloud-based Kubernetes environment.
 
@@ -366,4 +376,4 @@ Delete the policy, role, and S3 bucket that you configured for this tutorial.
 
 ## DNS Cleanup
 
-You can remove the A record that you configured for the SPIRE OIDC Discovery Provider document location using your preferred DNS tool.
+You can remove the A record that you configured for the SPIRE OIDC Discovery Provider document location.

--- a/content/spire/try/spire+aws-oidc-federation.md
+++ b/content/spire/try/spire+aws-oidc-federation.md
@@ -104,66 +104,6 @@ Apply the deployment file:
 $ kubectl apply -f client-deployment.yaml
 ```
 
-
-
-
-## Test AWS
-
-### Connect client
-
-Get:
-$ kubectl get pods 
-
-output:
-```
-$ kubectl get pods
-NAME                      READY   STATUS    RESTARTS   AGE
-client-74d4467b44-7nrs2   1/1     Running   0          27s
-```
-
-Go into:
-```
-$ kubectl exec -it client-74d4467b44-7nrs2 /bin/sh
-```
-
-### Get token
-I will fetch for an jwt svid and create a `token` file that includes only token from it.
-**replace `mys3` with your Authentication provider audience**
-```
-$ /opt/spire/bin/spire-agent api fetch jwt -audience mys3 -socketPath /run/spire/sockets/agent.sock | sed '2q' | sed 's/[[:space:]]//g' > token
-```
-
-### Access to aws
-It will connect to aws s3 using token from fetched svid
-***
-replace:
-- `${ROLE-NAME-ARN}` with your role arn on aws
-- `s3://oidc-federation-test/test.txt test.txt` replace with your configured s3 bucket
-***
-
-```
-$ AWS_ROLE_ARN=${ROLE-NAME-ARN} AWS_WEB_IDENTITY_TOKEN_FILE=token aws s3 cp s3://oidc-tutorial-bucket/test.txt test.txtt
-```
-
-## Clean
-
-### Delete client namespace
-```
-$ kubectl delete deployment client
-```
-
-### Delete spire namespace
-```
-$ kubectl delete namespace spire
-```
-
-
-
-
-
-
-======================================================================
-======================================================================
 # Part Two: Configure AWS Components
 
 After configuring the SPIRE components, continue with configuring AWS.
@@ -358,3 +298,16 @@ If successful, this command would output:
 ```console
 download: s3://oidc-federation-test-bucket/test.txt to ./test.txt
 ```
+
+## Cleanup
+
+### Delete client namespace
+```
+$ kubectl delete deployment client
+```
+
+### Delete spire namespace
+```
+$ kubectl delete namespace spire
+```
+


### PR DESCRIPTION
Kubernetes version of SPIRE OIDC Federation to AWS tutorial. This version makes most config decisions for the user user to make the tutorial experience easier for users new to SPIRE. This PR depends on Marcos Yacob's PR at https://github.com/spiffe/spire-tutorials/pull/13, which includes new YAML files for this tutorial.