### PR TITLE
Updates Hugo and it pins up to an specific version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,37 @@
+HUGO_VERSION ?= 0.68.3
+
 setup:
 	npm install
 
 serve:
 	HIDE_RELEASES=true hugo server \
-	--buildDrafts \
-	--buildFuture \
-	--disableFastRender \
-	--ignoreCache \
-	--noHTTPCache
+		--buildDrafts \
+		--buildFuture \
+		--disableFastRender \
+		--ignoreCache \
+		--noHTTPCache
 
 serve-with-releases:
 	hugo server \
-	--buildDrafts \
-	--buildFuture \
-	--disableFastRender
+		--buildDrafts \
+		--buildFuture \
+		--disableFastRender
 
 production-build:
 	hugo --gc
 
 preview-build:
-	hugo --baseURL $(DEPLOY_PRIME_URL)
+	hugo \
+		--gc \
+		--ignoreCache \
+		--baseURL $(DEPLOY_PRIME_URL)
 
 docker-serve:
-	docker run --rm -it -v $(PWD):/src -p 1313:1313 -e HIDE_RELEASES=true klakegg/hugo:latest-ext server --buildDrafts --buildFuture
+	docker run --rm -it -v $(PWD):/src -p 1313:1313 -e HIDE_RELEASES=true \
+		klakegg/hugo:${HUGO_VERSION}-ext \
+		server --buildDrafts --buildFuture
 
 docker-serve-with-releases:
-	docker run --rm -it -v $(PWD):/src -p 1313:1313 klakegg/hugo:latest-ext server --buildDrafts --buildFuture
+	docker run --rm -it -v $(PWD):/src -p 1313:1313 \
+		klakegg/hugo:${HUGO_VERSION}-ext \
+		server --buildDrafts --buildFuture

--- a/config.toml
+++ b/config.toml
@@ -7,8 +7,9 @@ canonifyurls = true
 googleAnalytics = "UA-99605331-1"
 enableGitInfo = true
 
-[blackfriday]
-hrefTargetBlank = true
+[markup]
+  [markup.tableOfContents]
+    startLevel = 1
 
 [params]
 acronym = "Secure Production Identity Framework for Everyone"

--- a/content/spiffe/casestudies/_index.md
+++ b/content/spiffe/casestudies/_index.md
@@ -9,6 +9,6 @@ menu:
 
 {{< presentations category="case-study" >}}
 
-<hr/>
+---
 
 You can find more presentations on a variety of topics concerning SPIFFE and SPIRE on our [Community Presentations](/community/presentations/) page.

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text | safeURL }}</a>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.59.1"
+HUGO_VERSION = "0.68.3"
 
 [context.deploy-preview]
 command = "make preview-build"


### PR DESCRIPTION
- Updates Hugo to the latest version, v0.68.3
- It pins up to that specific version to avoid future Hugo releases breaking the build or content
- Some other minor changes required to make the content render the same way it was with version 0.59.1