### PR TITLE
Ignore build cache when building on production mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ serve-with-releases:
 	--disableFastRender
 
 production-build:
-	hugo --gc
+	hugo \
+		--gc \
+		--ignoreCache
 
 preview-build:
 	hugo --baseURL $(DEPLOY_PRIME_URL)


### PR DESCRIPTION
This is another try to fix #36 

cc @lucperkins 