### PR TITLE
Shorten intra-site URLs to prevent new browser tabs

### DIFF
--- a/content/spire/concepts.md
+++ b/content/spire/concepts.md
@@ -12,7 +12,7 @@ menu:
 SPIRE is a production-ready implementation of the [SPIFFE APIs](/spiffe) that performs node and workload attestation in order to securely issue SVIDs to workloads, and verify the SVIDs of other workloads, based on a predefined set of conditions. 
 
 {{< info >}}
-SPIRE is just one implementation of the SPIFFE specification. For a list of current implementations, see the [spiffe.io homepage](https://spiffe.io). 
+SPIRE is just one implementation of the SPIFFE specification. For a list of current implementations, see the [spiffe.io homepage](/). 
 {{< /info >}}
 
 This section describes the architecture and components of SPIRE, walks you through “a day in the life of” how SPIRE issues an identity to a workload, and looks at some basic SPIRE concepts.

--- a/content/spire/try/getting-started-k8s.md
+++ b/content/spire/try/getting-started-k8s.md
@@ -262,4 +262,4 @@ As configured, the SPIRE agent does not verify the identity of the Kubernetes ku
 
 # Next steps
 
-* [Review the SPIRE Documentation](https://spiffe.io/spire/docs/) to learn how to configure SPIRE for your environment.
+* [Review the SPIRE Documentation](/spire/docs/) to learn how to configure SPIRE for your environment.

--- a/content/spire/try/getting-started-linux.md
+++ b/content/spire/try/getting-started-linux.md
@@ -67,7 +67,7 @@ Server is healthy.
 
 # Creating a join token to attest the agent to the server
 
-A join token is one of the many available agent attestor methods. It is a one-time-use, pre-shared key that attests (authenticates) the SPIRE agent to the SPIRE server. Other agent attestation methods include AWS/GCP instance identity tokens and X.509 certificates. To see a complete list of available attestors, click [here](https://spiffe.io/spire/overview/#selectors).
+A join token is one of the many available agent attestor methods. It is a one-time-use, pre-shared key that attests (authenticates) the SPIRE agent to the SPIRE server. Other agent attestation methods include AWS/GCP instance identity tokens and X.509 certificates. To see a complete list of available attestors, click [here](/spire/docs/registering/#1-defining-the-spiffe-id-of-the-agent).
 
 Generate a one-time-use token to use to attest the agent:
 
@@ -79,7 +79,7 @@ Token: <token_string>
 Make a note of the token, you will need it in the next step to attest the agent on initial startup.
 
 {{< info >}}
-A Join Token is just one of the many available agent attestation methods. To see a complete list of available attestors, click [here](https://spiffe.io/spire/overview/#selectors).
+A Join Token is just one of the many available agent attestation methods. To see a complete list of available attestors, click [here](/spire/docs/registering/#1-defining-the-spiffe-id-of-the-agent).
 {{< /info >}}
 
 # Starting the agent
@@ -121,7 +121,7 @@ Selector      : unix:uid:501
 ```
 
 {{< info >}}
-`unix` is just one of the available workload attestation methods. To see a complete list of available attestors, click [here](https://spiffe.io/spire/overview/#selectors).
+`unix` is just one of the available workload attestation methods. To see a complete list of available attestors, click [here](/spire/docs/registering/#2-defining-the-spiffe-id-of-the-workload).
 {{< /info >}}
 
 
@@ -194,4 +194,4 @@ Certificate:
 
 # Next steps
 
-* [Review the SPIRE Documentation](https://spiffe.io/spire/docs/) to learn how to configure SPIRE for your environment.
+* [Review the SPIRE Documentation](/spire/docs/) to learn how to configure SPIRE for your environment.


### PR DESCRIPTION
Links to other pages on spiffe.io that used the full URL would open in
a new browser tab instead of the same browser tab. This commit also
fixes some broken links in the Linux/Mac getting started guide.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>