### PR TITLE
Temporarily add SPIFFE Community Day Spr 2020 promo

### DIFF
--- a/layouts/partials/home/newsbar.html
+++ b/layouts/partials/home/newsbar.html
@@ -1,17 +1,6 @@
 <section class="newsbar is-medium is-light">
     <div class="has-text-centered">
       <div class="container">
-        <div class="columns is-vcentered">
-          <div class="column is-one-third video-text">
-            <p class="is-size-4 is-size-5-mobile">New to SPIFFE and SPIRE? Learn the basics in 10 minutes.</p>
-          </div>
-          
-          <div class="column is-paddingless video-wrapper">
-            <br>
-            <div class="embed-container">
-              <iframe src="https://www.youtube.com/embed/Q2SiGeebRKY" frameborder="0"></iframe>
-            </div>
-        </div>
-      </div>
+        <p class="is-size-4 is-size-5-mobile">Join us virtually on April 24 for the Spring 2020 SPIFFE Community Day  &mdash; <a href="https://spiffecommunitydayspring2020.splashthat.com/">Register here!</a></p>
     </div>
   </section>


### PR DESCRIPTION
Per Umair Khan in marketing, I’ve temporarily replaced Evan's SPIFFE
intro video with promo text for the SPIFFE Community Day Spring 2020.
We’ll put the video back after April 24, 2020.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>