### PR TITLE
Fix spire server/agent install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,19 @@ Markdown sources for the documentation are in the [`content`](content) directory
 
 #### Latest SPIRE version
 
-Hugo can automatically infer the latest version of SPIRE using the GitHub [Releases API](https://developer.github.com/v3/repos/releases/). To insert that version into text, use the [`spire-latest`](layouts/shortcodes/spire-latest.html) [shortcode](#shortcodes). Here's an example:
+Hugo can automatically infer the latest version of SPIRE using the GitHub [Releases API](https://developer.github.com/v3/repos/releases/). To insert that version into text, use the [`spire-latest`](layouts/shortcodes/spire-latest.html) [shortcode](#shortcodes).
+This shortcode has a mandatory parameter that can be either `version`, `tag` or `tarball`.
+
+Here's an example:
 
 ```markdown
-The most recent version of SPIRE is {{< spire-latest >}}.
+The most recent version of SPIRE is "{{< spire-latest "version" >}}", that is tagged as "{{< spire-latest "tag" >}}" and packed in the file "{{< spire-latest "tarball" >}}"
+```
+
+that will generate the following output:
+
+```
+The most recent version of SPIRE is "0.9.3", that is tagged as "v0.9.3" and packed in the file "spire-0.9.3-linux-x86_64-glibc.tar.gz"
 ```
 
 ### The Downloads page

--- a/content/spire/docs/install-agents.md
+++ b/content/spire/docs/install-agents.md
@@ -26,9 +26,9 @@ To install the server and agent:
 1. Obtain the latest tarball from the [SPIRE downloads page](/downloads#spire) and then extract it into the **/opt/spire** directory using the following commands:
 
     ```console
-    wget https://github.com/spiffe/spire/releases/download/{{< spire-latest >}}/spire-{{< spire-latest >}}-linux-x86_64-glibc.tar.gz
-    sudo tar zvxf spire-{{< spire-latest >}}-linux-x86_64-glibc.tar.gz
-    sudo cp -r spire-{{< spire-latest >}}/. /opt/spire/
+    wget https://github.com/spiffe/spire/releases/download/{{< spire-latest "tag" >}}/{{< spire-latest "tarball" >}}
+    sudo tar zvxf {{< spire-latest "tarball" >}}
+    sudo cp -r spire-{{< spire-latest "version" >}}/. /opt/spire/
     ```
 
 2. Add `spire-server` and `spire-agent` to your $PATH for convenience:

--- a/content/spire/docs/install-agents.md
+++ b/content/spire/docs/install-agents.md
@@ -27,15 +27,15 @@ To install the server and agent:
 
     ```console
     wget https://github.com/spiffe/spire/releases/download/{{< spire-latest "tag" >}}/{{< spire-latest "tarball" >}}
-    sudo tar zvxf {{< spire-latest "tarball" >}}
+    tar zvxf {{< spire-latest "tarball" >}}
     sudo cp -r spire-{{< spire-latest "version" >}}/. /opt/spire/
     ```
 
 2. Add `spire-server` and `spire-agent` to your $PATH for convenience:
 
     ```console
-    ln -s /opt/spire/spire-server /usr/bin/spire-server
-    ln -s /opt/spire/spire-agent /usr/bin/spire-agent
+    sudo ln -s /opt/spire/bin/spire-server /usr/bin/spire-server
+    sudo ln -s /opt/spire/bin/spire-agent /usr/bin/spire-agent
     ```
 
 ## Step 3: Configure the Agent {#step-3}

--- a/content/spire/docs/install-server.md
+++ b/content/spire/docs/install-server.md
@@ -26,9 +26,9 @@ To install the server and agent:
 1. Obtain the latest tarball from the [SPIRE downloads page](/downloads#spire) and then extract it into the **/opt/spire** directory using the following commands:
 
     ```console
-    wget https://github.com/spiffe/spire/releases/download/{{< spire-latest >}}/spire-{{< spire-latest >}}-linux-x86_64-glibc.tar.gz
-    sudo tar zvxf spire-{{< spire-latest >}}-linux-x86_64-glibc.tar.gz
-    sudo cp -r spire-{{< spire-latest >}}/. /opt/spire/
+    wget https://github.com/spiffe/spire/releases/download/{{< spire-latest "tag" >}}/{{< spire-latest "tarball" >}}
+    sudo tar zvxf {{< spire-latest "tarball" >}}
+    sudo cp -r spire-{{< spire-latest "version" >}}/. /opt/spire/
     ```
 
 2. Add `spire-server` and `spire-agent` to your $PATH for convenience:

--- a/content/spire/docs/install-server.md
+++ b/content/spire/docs/install-server.md
@@ -27,15 +27,15 @@ To install the server and agent:
 
     ```console
     wget https://github.com/spiffe/spire/releases/download/{{< spire-latest "tag" >}}/{{< spire-latest "tarball" >}}
-    sudo tar zvxf {{< spire-latest "tarball" >}}
+    tar zvxf {{< spire-latest "tarball" >}}
     sudo cp -r spire-{{< spire-latest "version" >}}/. /opt/spire/
     ```
 
 2. Add `spire-server` and `spire-agent` to your $PATH for convenience:
 
     ```console
-    ln -s /opt/spire/spire-server /usr/bin/spire-server
-    ln -s /opt/spire/spire-agent /usr/bin/spire-agent
+    sudo ln -s /opt/spire/bin/spire-server /usr/bin/spire-server
+    sudo ln -s /opt/spire/bin/spire-agent /usr/bin/spire-agent
     ```
 
 ## Step 3: Configure the Server {#step-3}

--- a/layouts/shortcodes/spire-latest.html
+++ b/layouts/shortcodes/spire-latest.html
@@ -1,9 +1,17 @@
 {{- $displayReleases  := ne (getenv "HIDE_RELEASES") "true" }}
 {{- if $displayReleases }}
-{{- $releasesUrl := "https://api.github.com/repos/spiffe/spire/releases" }}
-{{- $releases    := getJSON $releasesUrl }}
-{{- $latest      := (index $releases 0).tag_name }}
-{{- $latest -}}
+  {{- $releasesUrl   := "https://api.github.com/repos/spiffe/spire/releases" }}
+  {{- $releases      := getJSON $releasesUrl }}
+  {{- $latestTag     := (index $releases 0).tag_name }}
+
+  {{- if eq (.Get 0) "tag" }}
+    {{- $latestTag -}}
+  {{- else if eq (.Get 0) "version" -}}
+    {{- index (findRE "([0-9.]+)" $latestTag) 0 }}
+  {{- else if eq (.Get 0) "tarball" -}}
+    {{- (index (index $releases 0).assets 0).name -}}
+  {{- end -}}
+
 {{- else -}}
-LATEST
+  LATEST-{{- (.Get 0) -}}
 {{- end -}}


### PR DESCRIPTION
Starting from version 0.9.2, SPIRE has been prefixing the git tag name with a `v` (for example `v.0.9.2`), and this caused some mismatches with the installation instructions for the server and agent.

This PR introduces a new parameter to the `latest-spire` shortcode, that can be either `version`,`tag` or `tarball` to be used as necessary.