### PR TITLE
Fix issues reported by @MarcosDY re SPIRE 0.10.0

### DIFF
--- a/content/spire/docs/configuring.md
+++ b/content/spire/docs/configuring.md
@@ -219,7 +219,7 @@ _This configuration applies to the SPIRE Server and SPIRE Agent_
 
 The `data_dir` option in the `agent.conf` and `server.conf` configuration files sets the directory for SPIRE runtime data.
 
-If you specify a relative path for `data_dir` by starting the path with `./` then `data_dir` is evaluated based on the current working directory from which you run the SPIRE Agent or Server. Using a relative path for `data_dir` can be useful for initial evaluation of SPIRE, but for production deployments you may want to set `data_dir` to an absolute path. By convention, specify `"/opt/spire/data"` for `data_dir` if you have installed SPIRE in `/opt/spire`.
+If you specify a relative path for `data_dir` by starting the path with `./` then `data_dir` is evaluated based on the current working directory from which you run the `spire-agent` or `spire-server` command. Using a relative path for `data_dir` can be useful for an initial trial of SPIRE, but for production deployments you may want to set `data_dir` to an absolute path. By convention, specify `"/opt/spire/data"` for `data_dir` if you have installed SPIRE in `/opt/spire`.
 
 Ensure the path that you specify for `data_dir` and all subdirectories are readable by the Linux user that runs the SPIRE Agent or Server executable. You may want to use [chown](http://man7.org/linux/man-pages/man1/chown.1.html) to change the ownership of these data directories to the Linux user that will run the executable.
 

--- a/content/spire/docs/configuring.md
+++ b/content/spire/docs/configuring.md
@@ -214,6 +214,19 @@ The Unix Workload Attestor works by determining kernel metadata from the workloa
 
 For more information, including details of the exposed selectors, refer to the corresponding SPIRE documentation for the [Unix Workload Attestor plugin](https://github.com/spiffe/spire/blob/master/doc/plugin_agent_workloadattestor_unix.md).
 
+# Configuring where to store agent and server data
+_This configuration applies to the SPIRE Server and SPIRE Agent_
+
+The `data_dir` option in the `agent.conf` and `server.conf` configuration files sets the directory for SPIRE runtime data.
+
+If you specify a relative path for `data_dir` by starting the path with `./` then `data_dir` is evaluated based on the current working directory from which you run the SPIRE Agent or Server. Using a relative path for `data_dir` can be useful for initial evaluation of SPIRE, but for production deployments you may want to set `data_dir` to an absolute path. By convention, specify `"/opt/spire/data"` for `data_dir` if you have installed SPIRE in `/opt/spire`.
+
+Ensure the path that you specify for `data_dir` and all subdirectories are readable by the Linux user that runs the SPIRE Agent or Server executable. You may want to use [chown](http://man7.org/linux/man-pages/man1/chown.1.html) to change the ownership of these data directories to the Linux user that will run the executable.
+
+If the path that you specify for `data_dir` does not exist, the SPIRE Agent or Server executable will create the path if the Linux user that runs the executable has permissions to do so.
+
+Typically you should use the value for `data_dir` as the base directory for other data paths that you configure in the `agent.conf` and `server.conf` configuration files. For example, if you set `data_dir` to `"/opt/spire/data"` in `agent.conf`, set the `KeyManager "disk" plugin_data directory` to `"/opt/spire/data/agent"`. Or, if you set `data_dir` to `/opt/spire/data` in `server.conf`, set the `connection_string` to `"/opt/spire/data/server/datastore.sqlite3"` if you use SQLite for the SPIRE Server data-store as described next.
+
 # Configuring how to store server data
 _This configuration applies to the SPIRE Server_
 

--- a/content/spire/docs/configuring.md
+++ b/content/spire/docs/configuring.md
@@ -219,7 +219,7 @@ _This configuration applies to the SPIRE Server and SPIRE Agent_
 
 The `data_dir` option in the `agent.conf` and `server.conf` configuration files sets the directory for SPIRE runtime data.
 
-If you specify a relative path for `data_dir` by starting the path with `./` then `data_dir` is evaluated based on the current working directory from which you run the `spire-agent` or `spire-server` command. Using a relative path for `data_dir` can be useful for an initial trial of SPIRE, but for production deployments you may want to set `data_dir` to an absolute path. By convention, specify `"/opt/spire/data"` for `data_dir` if you have installed SPIRE in `/opt/spire`.
+If you specify a relative path for `data_dir` by starting the path with `./` then `data_dir` is evaluated based on the current working directory from which you executed the `spire-agent` or `spire-server` command. Using a relative path for `data_dir` can be useful for an initial assessment of SPIRE, but for production deployments you may want to set `data_dir` to an absolute path. By convention, specify `"/opt/spire/data"` for `data_dir` if you have installed SPIRE in `/opt/spire`.
 
 Ensure the path that you specify for `data_dir` and all subdirectories are readable by the Linux user that runs the SPIRE Agent or Server executable. You may want to use [chown](http://man7.org/linux/man-pages/man1/chown.1.html) to change the ownership of these data directories to the Linux user that will run the executable.
 

--- a/content/spire/docs/install-server.md
+++ b/content/spire/docs/install-server.md
@@ -51,12 +51,6 @@ However, to get a simple deployment up and running for demonstration purposes, y
 
 To configure the items in steps 1, 2, and 4, edit the server’s configuration file, located in **/opt/spire/conf/server/server.conf**.
 
-Pre-built binaries require you to create a **.data** directory. For example, if you've installed SPIRE in the default **/opt/spire** location, type:
-
-```console
-sudo mkdir -p /opt/spire/.data
-```
-
 See [Configuring SPIRE](/spire/docs/configuring/) for details about how to configure SPIRE, in particular Node Attestation and Workload Attestation.
 
 Note that a SPIRE Server must be restarted once its configuration has been modified for changes to take effect.
@@ -73,7 +67,7 @@ You must run all commands from the directory containing the **.yaml** files used
 
 ## Step 1: Obtain the Required Files {#section-1}
 
-To obtain the required **.yaml** files, clone **https://github.com/spiffe/spire-tutorials** and copy the **.yaml** files from the **spire-tutorials/k8s** subdirectory.
+To obtain the required **.yaml** files, clone **https://github.com/spiffe/spire-tutorials** and copy the **.yaml** files from the **spire-tutorials/k8s/quickstart** subdirectory.
 
 ## Step 2: Configure Kubernetes Namespace for SPIRE Components {#section-2}
 


### PR DESCRIPTION
Fix these issues reported by @MarcosDY in his review of the SPIRE docs
to coincide with the release of SPIRE 0.10.0:
* Kubernetes YAML files are in a quickstart subdirectory now
* Recommended location of data_dir is no longer "/opt/spire/.data" but
  "/opt/spire/data"
  I added a new section to configuring.md describing the data_dir
  setting and removed info about data_dir from install-server.md.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>