### PR TITLE
Replace community day info with SPIRE intro video

### DIFF
--- a/layouts/partials/home/newsbar.html
+++ b/layouts/partials/home/newsbar.html
@@ -1,6 +1,17 @@
 <section class="newsbar is-medium is-light">
     <div class="has-text-centered">
       <div class="container">
-        <p class="is-size-4 is-size-5-mobile">Join us virtually on April 24 for the Spring 2020 SPIFFE Community Day  &mdash; <a href="https://spiffecommunitydayspring2020.splashthat.com/">Register here!</a></p>
+        <div class="columns is-vcentered">
+          <div class="column is-one-third video-text">
+            <p class="is-size-4 is-size-5-mobile">New to SPIFFE and SPIRE? Learn the basics in 10 minutes.</p>
+          </div>
+          
+          <div class="column is-paddingless video-wrapper">
+            <br>
+            <div class="embed-container">
+              <iframe src="https://www.youtube.com/embed/Q2SiGeebRKY" frameborder="0"></iframe>
+            </div>
+        </div>
+      </div>
     </div>
   </section>


### PR DESCRIPTION
This reverts the spiffe.io home page to the previous state before the Spring 2020 community day info was added.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>