### PR TITLE
NON-WORKING attempt to show spire-extras tarball

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -15,6 +15,11 @@ The table [below](#spire-releases) lists the available releases for [SPIRE](/spi
 * The SPIRE source code as a zip file
 * The SPIRE source code as a tarball
 
+Starting with SPIRE v0.10.0, an additional `spire-extras` tarball is available that contains the following binaries:
+
+* OIDC Discovery Provider
+* Kubernetes Workload Registrar
+
 ## SPIRE releases
 
 {{< releases >}}

--- a/layouts/shortcodes/releases.html
+++ b/layouts/shortcodes/releases.html
@@ -21,6 +21,7 @@
     {{- $releases         := getJSON $spireReleasesUrl }}
     {{- range $releases }}
     {{- $latest           := (index $releases 0).tag_name }}
+    {{- $hasExtras        := (index .assets 2).name }}
     {{- $clipboardButtons := .Site.Params.downloads.buttons.clipboard }}
     {{- $downloadButtons  := .Site.Params.downloads.buttons.download }}
 
@@ -29,6 +30,12 @@
     {{- $isLatest     := eq $version $latest }}
     {{- $tar          := (index .assets 0).name }}
     {{- $zip          := (index .assets 1).name }}
+{{/*   {{- if $hasExtras }} */}}
+    {{- $extras       := (index .assets 2).name }}
+    {{- $extrasChecksum := (index .assets 3).name }}
+    {{- $extrasTarUrl  := printf "%s/%s/%s" $downloadUrl $version $extras }}
+    {{- $extrasChecksumUrl := printf "%s/%s/%s" $downloadUrl $version $extrasChecksum }}
+{{/*   {{- end }}  */}}
     {{- $binaryTarUrl := printf "%s/%s/%s" $downloadUrl $version $tar }}
     {{- $checksumsUrl := printf "%s/%s/%s" $downloadUrl $version $zip }}
     {{- $sourceZipUrl := printf "https://github.com/spiffe/spire/archive/%s.zip" $version }}
@@ -49,7 +56,11 @@
       <td>
         <div class="buttons">
           {{ partial "downloads/download-button.html" (dict "url" $binaryTarUrl "text" "Binaries (.tar.gz)" "isDownloadButton" false "color" "dark") }}
-          {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksums (.txt)" "isDownloadButton" false "color" "dark") }}
+          {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksum (.txt)" "isDownloadButton" false "color" "dark") }}
+{{/*              {{- if $hasExtras -}} */}}
+          {{ partial "downloads/download-button.html" (dict "url" $extrasTarUrl "text" "Extras (.tar.gz)" "isDownloadButton" false "color" "dark") }}
+          {{ partial "downloads/download-button.html" (dict "url" $extrasChecksumUrl "text" "Extras Checksum (.txt)" "isDownloadButton" false "color" "dark") }}
+{{/*          {{- end }} */}}
           {{ partial "downloads/download-button.html" (dict "url" $sourceZipUrl "text" "Source (.zip)" "isDownloadButton" false "color" "light") }}
           {{ partial "downloads/download-button.html" (dict "url" $sourceTarUrl "text" "Source (.tar.gz)" "isDownloadButton" false "color" "light") }}
         </div>
@@ -58,7 +69,11 @@
       <td>
         <div class="buttons">
           {{ partial "downloads/download-button.html" (dict "url" $binaryTarUrl "text" "Binaries (.tar.gz)" "isDownloadButton" true "color" "dark") }}
-          {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksums (.txt)" "isDownloadButton" true "color" "dark") }}
+          {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksum (.txt)" "isDownloadButton" true "color" "dark") }}
+{{/*              {{- if $hasExtras -}} */}}
+          {{ partial "downloads/download-button.html" (dict "url" $extrasTarUrl "text" "Extras (.tar.gz)" "isDownloadButton" true "color" "dark") }}
+          {{ partial "downloads/download-button.html" (dict "url" $extrasChecksumUrl "text" "Extras Checksum (.txt)" "isDownloadButton" true "color" "dark") }}
+{{/*          {{- end }} */}}
           {{ partial "downloads/download-button.html" (dict "url" $sourceZipUrl "text" "Source (.zip)" "isDownloadButton" true "color" "light") }}
           {{ partial "downloads/download-button.html" (dict "url" $sourceTarUrl "text" "Source (.tar.gz)" "isDownloadButton" true "color" "light") }}
         </div>


### PR DESCRIPTION
The problem is that it shows the spire-extras tarball for all older
releases, not just 0.10.0.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>