### PR TITLE
Update get spire for v0.10.0

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -11,14 +11,14 @@ The table [below](#spire-releases) lists the available releases for [SPIRE](/spi
   * The `spire-agent` and `spire-server` binaries
   * Configuration for the SPIRE agent and server
   * A [Docker Compose](https://docs.docker.com/compose) configuration that enables you to run an agent and a server simultaneously using [Docker](https://docker.com)
-* A `.txt` file containing checksums for the binary tarball
+* A `.txt` file containing the SHA-256 checksum for the binary tarball
 * The SPIRE source code as a zip file
 * The SPIRE source code as a tarball
 
-Starting with SPIRE v0.10.0, an additional `spire-extras` tarball is available that contains the following binaries:
+Starting with SPIRE v0.10.0, a `spire-extras` tarball is available that contains the following binaries:
 
-* OIDC Discovery Provider
-* Kubernetes Workload Registrar
+* [OIDC Discovery Provider](https://github.com/spiffe/spire/blob/master/support/oidc-discovery-provider/README.md)
+* [Kubernetes Workload Registrar](https://github.com/spiffe/spire/blob/master/support/k8s/k8s-workload-registrar/README.md)
 
 ## SPIRE releases
 
@@ -27,6 +27,13 @@ Starting with SPIRE v0.10.0, an additional `spire-extras` tarball is available t
 This document tells you how to build [SPIRE](/spire) from source, perhaps because you'd like to try out an unreleased version.
 
 # Build from Source
+
+To build SPIRE from source on Linux, you'll need:
+* `git` - To clone the source from GitHub
+* `make` - To run the Makefile
+* `gcc` - To build the binaries
+
+The build script installs the required toolchain as needed, except for `gcc`. For example, the build script installs a private version of `go` that has been verified to successfully build SPIRE.
 
 ## Fetching
 
@@ -42,17 +49,13 @@ The SPIRE codebase uses [Go modules](https://github.com/golang/go/wiki/Modules),
 
 ## Building
 
-{{< requirement >}}
-To build SPIRE from source, you'll need [Go 1.11](https://golang.org/dl) or higher.
-{{< /requirement >}}
-
-To build the `spire-agent` and `spire-server` binaries from source:
+To build the binaries from source:
 
 ```bash
-$ make all
+$ make build
 ```
 
-The built binaries are available in `bin/spire-agent` and `bin/spire-server`, respectively.
+The built binaries are placed in `bin`.
 
 ## Getting help
 

--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -7,7 +7,7 @@ toc: true
 
 The table [below](#spire-releases) lists the available releases for [SPIRE](/spire). The following is available for each release:
 
-* A tarball for Linux operating systems containing:
+* A tarball for Linux x86_64 operating systems containing:
   * The `spire-agent` and `spire-server` binaries
   * Configuration files for the SPIRE Agent and Server
   * A [Docker Compose](https://docs.docker.com/compose) configuration that enables you to run an agent and a server simultaneously using [Docker](https://docker.com)
@@ -15,7 +15,7 @@ The table [below](#spire-releases) lists the available releases for [SPIRE](/spi
 * The SPIRE source code as a zip file
 * The SPIRE source code as a tarball
 
-Starting with SPIRE v0.10.0, a `spire-extras` tarball is available that contains the following binaries for Linux operating systems:
+Starting with SPIRE v0.10.0, a `spire-extras` tarball is available that contains the following binaries for Linux x86_64 operating systems:
 
 * [OIDC Discovery Provider](https://github.com/spiffe/spire/blob/master/support/oidc-discovery-provider/README.md)
 * [Kubernetes Workload Registrar](https://github.com/spiffe/spire/blob/master/support/k8s/k8s-workload-registrar/README.md)

--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -3,37 +3,37 @@ title: Get SPIRE
 toc: true
 ---
 
-# Download pre-built SPIRE Releases
+# Download SPIRE Source and Linux Binaries
 
 The table [below](#spire-releases) lists the available releases for [SPIRE](/spire). The following is available for each release:
 
-* A tarball containing:
+* A tarball for Linux operating systems containing:
   * The `spire-agent` and `spire-server` binaries
-  * Configuration for the SPIRE agent and server
+  * Configuration files for the SPIRE Agent and Server
   * A [Docker Compose](https://docs.docker.com/compose) configuration that enables you to run an agent and a server simultaneously using [Docker](https://docker.com)
 * A `.txt` file containing the SHA-256 checksum for the binary tarball
 * The SPIRE source code as a zip file
 * The SPIRE source code as a tarball
 
-Starting with SPIRE v0.10.0, a `spire-extras` tarball is available that contains the following binaries:
+Starting with SPIRE v0.10.0, a `spire-extras` tarball is available that contains the following binaries for Linux operating systems:
 
 * [OIDC Discovery Provider](https://github.com/spiffe/spire/blob/master/support/oidc-discovery-provider/README.md)
 * [Kubernetes Workload Registrar](https://github.com/spiffe/spire/blob/master/support/k8s/k8s-workload-registrar/README.md)
 
-## SPIRE releases
+## SPIRE Releases
 
 {{< releases >}}
-
-This document tells you how to build [SPIRE](/spire) from source, perhaps because you'd like to try out an unreleased version.
 
 # Build from Source
 
 To build SPIRE from source on Linux, you'll need:
-* `git` - To clone the source from GitHub
+* `git` - To clone the source from GitHub. Alternatively, you could use `curl` or `wget`.
 * `make` - To run the Makefile
 * `gcc` - To build the binaries
 
 The build script installs the required toolchain as needed, except for `gcc`. For example, the build script installs a private version of `go` that has been verified to successfully build SPIRE.
+
+To build SPIRE on macOS, see [Building SPIRE on macOS/Darwin](/spire/try/getting-started-linux-macos-x/#building-spire-on-macosdarwin).
 
 ## Fetching
 
@@ -57,6 +57,6 @@ $ make build
 
 The built binaries are placed in `bin`.
 
-## Getting help
+## Getting Help
 
 If you run `make help`, you'll see a complete list of available `make` commands, along with descriptions of what those commands do.

--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -15,6 +15,11 @@ The table [below](#spire-releases) lists the available releases for [SPIRE](/spi
 * The SPIRE source code as a zip file
 * The SPIRE source code as a tarball
 
+Starting with SPIRE v0.10.0, an additional `spire-extras` tarball is available that contains the following binaries:
+
+* OIDC Discovery Provider
+* Kubernetes Workload Registrar
+
 ## SPIRE releases
 
 {{< releases >}}

--- a/layouts/shortcodes/releases.html
+++ b/layouts/shortcodes/releases.html
@@ -30,12 +30,14 @@
     {{- $isLatest     := eq $version $latest }}
     {{- $tar          := (index .assets 0).name }}
     {{- $zip          := (index .assets 1).name }}
-{{/*   {{- if $hasExtras }} */}}
-    {{- $extras       := (index .assets 2).name }}
-    {{- $extrasChecksum := (index .assets 3).name }}
-    {{- $extrasTarUrl  := printf "%s/%s/%s" $downloadUrl $version $extras }}
-    {{- $extrasChecksumUrl := printf "%s/%s/%s" $downloadUrl $version $extrasChecksum }}
-{{/*   {{- end }}  */}}
+    {{- $extrasChecksumUrl := "" -}}
+    {{- $extrasTarUrl      := "" -}}
+    {{- if $hasExtras }}
+      {{- $extras       := (index .assets 2).name }}
+      {{- $extrasChecksum := (index .assets 3).name }}
+      {{- $extrasTarUrl  = printf "%s/%s/%s" $downloadUrl $version $extras }}
+      {{- $extrasChecksumUrl = printf "%s/%s/%s" $downloadUrl $version $extrasChecksum }}
+    {{- end }}
     {{- $binaryTarUrl := printf "%s/%s/%s" $downloadUrl $version $tar }}
     {{- $checksumsUrl := printf "%s/%s/%s" $downloadUrl $version $zip }}
     {{- $sourceZipUrl := printf "https://github.com/spiffe/spire/archive/%s.zip" $version }}
@@ -57,10 +59,10 @@
         <div class="buttons">
           {{ partial "downloads/download-button.html" (dict "url" $binaryTarUrl "text" "Binaries (.tar.gz)" "isDownloadButton" false "color" "dark") }}
           {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksum (.txt)" "isDownloadButton" false "color" "dark") }}
-{{/*              {{- if $hasExtras -}} */}}
-          {{ partial "downloads/download-button.html" (dict "url" $extrasTarUrl "text" "Extras (.tar.gz)" "isDownloadButton" false "color" "dark") }}
-          {{ partial "downloads/download-button.html" (dict "url" $extrasChecksumUrl "text" "Extras Checksum (.txt)" "isDownloadButton" false "color" "dark") }}
-{{/*          {{- end }} */}}
+          {{- if $hasExtras -}}
+            {{ partial "downloads/download-button.html" (dict "url" $extrasTarUrl "text" "Extras (.tar.gz)" "isDownloadButton" false "color" "dark") }}
+            {{ partial "downloads/download-button.html" (dict "url" $extrasChecksumUrl "text" "Extras Checksum (.txt)" "isDownloadButton" false "color" "dark") }}
+          {{- end }}
           {{ partial "downloads/download-button.html" (dict "url" $sourceZipUrl "text" "Source (.zip)" "isDownloadButton" false "color" "light") }}
           {{ partial "downloads/download-button.html" (dict "url" $sourceTarUrl "text" "Source (.tar.gz)" "isDownloadButton" false "color" "light") }}
         </div>
@@ -70,10 +72,10 @@
         <div class="buttons">
           {{ partial "downloads/download-button.html" (dict "url" $binaryTarUrl "text" "Binaries (.tar.gz)" "isDownloadButton" true "color" "dark") }}
           {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksum (.txt)" "isDownloadButton" true "color" "dark") }}
-{{/*              {{- if $hasExtras -}} */}}
-          {{ partial "downloads/download-button.html" (dict "url" $extrasTarUrl "text" "Extras (.tar.gz)" "isDownloadButton" true "color" "dark") }}
-          {{ partial "downloads/download-button.html" (dict "url" $extrasChecksumUrl "text" "Extras Checksum (.txt)" "isDownloadButton" true "color" "dark") }}
-{{/*          {{- end }} */}}
+          {{- if $hasExtras -}}
+            {{ partial "downloads/download-button.html" (dict "url" $extrasTarUrl "text" "Extras (.tar.gz)" "isDownloadButton" true "color" "dark") }}
+            {{ partial "downloads/download-button.html" (dict "url" $extrasChecksumUrl "text" "Extras Checksum (.txt)" "isDownloadButton" true "color" "dark") }}
+          {{- end }}
           {{ partial "downloads/download-button.html" (dict "url" $sourceZipUrl "text" "Source (.zip)" "isDownloadButton" true "color" "light") }}
           {{ partial "downloads/download-button.html" (dict "url" $sourceTarUrl "text" "Source (.tar.gz)" "isDownloadButton" true "color" "light") }}
         </div>

--- a/layouts/shortcodes/releases.html
+++ b/layouts/shortcodes/releases.html
@@ -21,6 +21,7 @@
     {{- $releases         := getJSON $spireReleasesUrl }}
     {{- range $releases }}
     {{- $latest           := (index $releases 0).tag_name }}
+    {{- $hasExtras        := (index .assets 2).name }}
     {{- $clipboardButtons := .Site.Params.downloads.buttons.clipboard }}
     {{- $downloadButtons  := .Site.Params.downloads.buttons.download }}
 
@@ -29,6 +30,12 @@
     {{- $isLatest     := eq $version $latest }}
     {{- $tar          := (index .assets 0).name }}
     {{- $zip          := (index .assets 1).name }}
+{{/*   {{- if $hasExtras }} */}}
+    {{- $extras       := (index .assets 2).name }}
+    {{- $extrasChecksum := (index .assets 3).name }}
+    {{- $extrasTarUrl  := printf "%s/%s/%s" $downloadUrl $version $extras }}
+    {{- $extrasChecksumUrl := printf "%s/%s/%s" $downloadUrl $version $extrasChecksum }}
+{{/*   {{- end }}  */}}
     {{- $binaryTarUrl := printf "%s/%s/%s" $downloadUrl $version $tar }}
     {{- $checksumsUrl := printf "%s/%s/%s" $downloadUrl $version $zip }}
     {{- $sourceZipUrl := printf "https://github.com/spiffe/spire/archive/%s.zip" $version }}
@@ -49,7 +56,11 @@
       <td>
         <div class="buttons">
           {{ partial "downloads/download-button.html" (dict "url" $binaryTarUrl "text" "Binaries (.tar.gz)" "isDownloadButton" false "color" "dark") }}
-          {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksums (.txt)" "isDownloadButton" false "color" "dark") }}
+          {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksum (.txt)" "isDownloadButton" false "color" "dark") }}
+{{/*              {{- if $hasExtras -}} */}}
+          {{ partial "downloads/download-button.html" (dict "url" $extrasTarUrl "text" "Extras (.tar.gz)" "isDownloadButton" false "color" "dark") }}
+          {{ partial "downloads/download-button.html" (dict "url" $extrasChecksumUrl "text" "Extras Checksum (.txt)" "isDownloadButton" false "color" "dark") }}
+{{/*          {{- end }} */}}
           {{ partial "downloads/download-button.html" (dict "url" $sourceZipUrl "text" "Source (.zip)" "isDownloadButton" false "color" "light") }}
           {{ partial "downloads/download-button.html" (dict "url" $sourceTarUrl "text" "Source (.tar.gz)" "isDownloadButton" false "color" "light") }}
         </div>
@@ -58,7 +69,11 @@
       <td>
         <div class="buttons">
           {{ partial "downloads/download-button.html" (dict "url" $binaryTarUrl "text" "Binaries (.tar.gz)" "isDownloadButton" true "color" "dark") }}
-          {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksums (.txt)" "isDownloadButton" true "color" "dark") }}
+          {{ partial "downloads/download-button.html" (dict "url" $checksumsUrl "text" "Checksum (.txt)" "isDownloadButton" true "color" "dark") }}
+{{/*              {{- if $hasExtras -}} */}}
+          {{ partial "downloads/download-button.html" (dict "url" $extrasTarUrl "text" "Extras (.tar.gz)" "isDownloadButton" true "color" "dark") }}
+          {{ partial "downloads/download-button.html" (dict "url" $extrasChecksumUrl "text" "Extras Checksum (.txt)" "isDownloadButton" true "color" "dark") }}
+{{/*          {{- end }} */}}
           {{ partial "downloads/download-button.html" (dict "url" $sourceZipUrl "text" "Source (.zip)" "isDownloadButton" true "color" "light") }}
           {{ partial "downloads/download-button.html" (dict "url" $sourceTarUrl "text" "Source (.tar.gz)" "isDownloadButton" true "color" "light") }}
         </div>


### PR DESCRIPTION
* Explain new v0.10.0 spire-extras tarball & add links
* Clarified requirements for building SPIRE
* Changed "make all" to "make build" for less cruft
* Described build output in a more generic way
