### PR TITLE
Added link to SPIFFE auth using JWT with go-spiffe.

### DIFF
--- a/content/spire/try/spiffe-library-usage-examples.md
+++ b/content/spire/try/spiffe-library-usage-examples.md
@@ -19,3 +19,5 @@ The following code samples demonstrate how to use the libraries to establish and
 See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe) for more information about the SPIFFE Go library. As of May 2020, a [v2 version](https://github.com/spiffe/go-spiffe/tree/master/v2) of this library is in alpha.
 
 * [SPIFFE to SPIFFE authentication using X.509 SVIDs](https://github.com/spiffe/go-spiffe/tree/master/v2/examples/spiffe-tls)
+
+* [SPIFFE to SPIFFE authentication using JWT SVIDs](https://github.com/spiffe/go-spiffe/tree/master/v2/examples/spiffe-jwt-using-proxy)


### PR DESCRIPTION
This PR requires that https://github.com/spiffe/go-spiffe/pull/141 is merged first.