### PR TITLE
Update spiffe-library-usage-examples.md

### DIFF
--- a/content/spire/try/spiffe-library-usage-examples.md
+++ b/content/spire/try/spiffe-library-usage-examples.md
@@ -16,8 +16,18 @@ The following code samples demonstrate how to use the libraries to establish and
 
 # Go
 
-See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe) for more information about the SPIFFE Go library. As of May 2020, a [v2 version](https://github.com/spiffe/go-spiffe/tree/master/v2) of this library is in alpha.
+See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe/tree/master/v2) for more information about the SPIFFE Go library. 
 
 * [SPIFFE to SPIFFE authentication using X.509 SVIDs](https://github.com/spiffe/go-spiffe/tree/master/v2/examples/spiffe-tls)
 
 * [SPIFFE to SPIFFE authentication using JWT SVIDs](https://github.com/spiffe/go-spiffe/tree/master/v2/examples/spiffe-jwt-using-proxy)
+
+# Java
+
+See the [java-spiffe library GitHub page](https://github.com/spiffe/java-spiffe/tree/v2-api) for more information about the SPIFFE Go library. 
+
+* [Federation and TCP Support](https://github.com/spiffe/spiffe-example/tree/master/java-spiffe-federation-jboss)
+
+# C
+
+See the [c-spiffe library GitHub page](https://github.com/spiffe/c-spiffe) for more information about the SPIFFE Go library. 

--- a/content/spire/try/spiffe-library-usage-examples.md
+++ b/content/spire/try/spiffe-library-usage-examples.md
@@ -14,6 +14,10 @@ You can use one of the following libraries to fetch SVIDs and trust bundles from
 
 The following code samples demonstrate how to use the libraries to establish and maintain SPIFFE-enabled connections transparently between applications.
 
+# C
+
+See the [c-spiffe library GitHub page](https://github.com/spiffe/c-spiffe) for more information about the SPIFFE Go library. 
+
 # Go
 
 See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe/tree/master/v2) for more information about the SPIFFE Go library. 
@@ -28,6 +32,3 @@ See the [java-spiffe library GitHub page](https://github.com/spiffe/java-spiffe/
 
 * [Federation and TCP Support](https://github.com/spiffe/spiffe-example/tree/master/java-spiffe-federation-jboss)
 
-# C
-
-See the [c-spiffe library GitHub page](https://github.com/spiffe/c-spiffe) for more information about the SPIFFE Go library. 


### PR DESCRIPTION
go-spiffe is now stable. Added links to java and c.