### PR TITLE
Change URL for Medium in header and footer buttons

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ spire = "**SPIRE**, the SPIFFE Runtime Environment, is an extensible system that
 [params.socialmedia]
 twitter       = "SPIFFEio"
 slack         = "https://slack.spiffe.io/"
-medium        = "https://scytale.io/blog/"
+medium        = "https://blog.spiffe.io/"
 github        = "https://github.com/spiffe"
 stackoverflow = "https://stackoverflow.com/questions/tagged/spiffe"
 


### PR DESCRIPTION
The URL for the SPIFFE blog has changed. The content of the blog has
been refreshed. This change is per Umair Khan of HPE.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>