### PR TITLE
Add YouTube social button to header + footer

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -9,6 +9,7 @@ $twitter-blue: #1da1f3
 $stack-overflow-orange: #f48024
 $slack-green: #74cdb0
 $linkedin-blue: #0077b5
+$youtube-red: #c4302b
 
 @import "bulma/sass/utilities/initial-variables"
 @import "bulma/sass/utilities/functions"
@@ -21,7 +22,7 @@ $link-hover: $spiffe-green
 
 @import "bulma/sass/utilities/derived-variables"
 
-$colors: mergeColorMaps(("twitter-blue": ($twitter-blue, $white), "stack-overflow-orange": ($stack-overflow-orange, $white), "slack-green": ($slack-green, $white), "linkedin-blue": ($linkedin-blue, $white)), $colors)
+$colors: mergeColorMaps(("twitter-blue": ($twitter-blue, $white), "stack-overflow-orange": ($stack-overflow-orange, $white), "slack-green": ($slack-green, $white), "linkedin-blue": ($linkedin-blue, $white), "youtube-red": ($youtube-red, $white)), $colors)
 $card-shadow: none
 $code: $dark
 $code-background: $white-ter

--- a/config.toml
+++ b/config.toml
@@ -30,6 +30,7 @@ slack         = "https://slack.spiffe.io/"
 medium        = "https://blog.spiffe.io/"
 github        = "https://github.com/spiffe"
 stackoverflow = "https://stackoverflow.com/questions/tagged/spiffe"
+youtube       = "https://www.youtube.com/channel/UCVzeW7j02FDNggkI5JKPvJg/f"
 
 [params.assets]
 js = [

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,6 +7,7 @@
 {{- $stackUrl           := $social.stackoverflow }}
 {{- $githubUrl          := $social.github }}
 {{- $blogUrl            := $social.medium }}
+{{- $youtubeUrl         := $social.youtube }}
 {{- $sourceGithubURL    := .Site.Params.githubURL }}     
 
 <footer class="footer has-background-dark">
@@ -97,6 +98,16 @@
               StackOverflow
             </span>
           </a>
+
+          <a class="button is-youtube-red" href="{{ $youtubeUrl }}">
+            <span class="icon">
+              <i class="fab fa-youtube"></i>
+            </span>
+            <span>
+              YouTube
+            </span>
+          </a>
+
         </div>
       </div>
     </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -10,6 +10,7 @@
 {{- $blogUrl         := $social.medium }}
 {{- $githubUrl       := $social.github }}
 {{- $stackUrl        := $social.stackoverflow }}
+{{- $youtubeUrl      := $social.youtube }}
 <nav class="navbar is-fixed-top is-light">
   <div class="container">
     <div class="navbar-brand">
@@ -141,6 +142,12 @@
             <a class="button is-stack-overflow-orange" href="{{ $stackUrl }}">
               <span class="icon">
                 <i class="fab fa-stack-overflow"></i>
+              </span>
+            </a>
+
+            <a class="button is-youtube-red" href="{{ $youtubeUrl }}">
+              <span class="icon">
+                <i class="fab fa-youtube"></i>
               </span>
             </a>
           </p>


### PR DESCRIPTION
Hi Max, 
Maybe you can take a look at this and get the color styling working?
-Steve


Per Umair Khan, add YouTube social button to header and footer of all
pages. The link points to the SPIFFE YouTube channel.

Currently, the CSS styling for setting the color of the button isn't
working. There doesn't seem to be a styling set up for a YouTube
social icon in the following file:
./resources/_gen/assets/sass/sass/style.sass_9f01a0c1d1634a317edafe1745cc4bff.content

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>