### PR TITLE
Update StringMatcher method to authorized SPIFFE Ids on Envoy page.

### DIFF
--- a/content/spire/docs/envoy.md
+++ b/content/spire/docs/envoy.md
@@ -86,6 +86,6 @@ tls_context:
               cluster_name: spire_agent
 ```
 
-SPIFFE and SPIRE are focused on facilitating secure authentication as a building block for authorization, not authorization itself, and as such support for authorization-related fields in the validation context (e.g. `verify_subject_alt_name`) is out of scope. Instead, we recommend you leverage Envoy’s extensive filter framework for performing authorization.
+SPIFFE and SPIRE are focused on facilitating secure authentication as a building block for authorization, not authorization itself, and as such support for authorization-related fields in the validation context (e.g. `match_subject_alt_names`) is out of scope. Instead, we recommend you leverage Envoy’s extensive filter framework for performing authorization.
 
 Additionally, you can configure Envoy to forward client certificate details to the destination service, allowing it to perform its own authorization steps, for example by using the SPIFFE ID embedded in the URI SAN of the client X.509-SVID.

--- a/content/spire/docs/install-agents.md
+++ b/content/spire/docs/install-agents.md
@@ -118,7 +118,7 @@ $ kubectl get pods --namespace spire
 
 NAME                           READY   STATUS    RESTARTS   AGE
 spire-agent-88cpl              1/1     Running   0          6m45s
-spire-server-b95945658-4wbkd   1/1     Running   0          103m
+spire-server-0                 1/1     Running   0          103m
 ```
 
 When the agent deploys, it binds the volumes summarized in the following table:

--- a/content/spire/try/getting-started-k8s.md
+++ b/content/spire/try/getting-started-k8s.md
@@ -134,7 +134,7 @@ $ kubectl get pods --namespace spire
 
 NAME                           READY   STATUS    RESTARTS   AGE
 spire-agent-88cpl              1/1     Running   0          6m45s
-spire-server-b95945658-4wbkd   1/1     Running   0          103m
+spire-server-0                 1/1     Running   0          103m
 ```
 
 As a daemonset, you'll see as many **spire-agent** pods as you have nodes.
@@ -192,7 +192,7 @@ You can test that the agent socket is accessible from an application container b
 3. Obtain a shell connection to the running pod:
 
     ```bash
-    $ kubectl exec -it client-6f9659bd44-m98vv /bin/sh
+    $ kubectl exec -it client-6f9659bd44-m98vv -- /bin/sh
     ```
 
 4. Verify the container can access the socket:

--- a/content/spire/try/oidc-federation-aws.md
+++ b/content/spire/try/oidc-federation-aws.md
@@ -338,7 +338,7 @@ Now that SPIRE in Kubernetes, the DNS A record for the OIDC Discovery document e
 
    ```console
    $ kubectl exec -it $(kubectl get pods -o \
-       jsonpath={'.items[*]'.metadata.name}) /bin/sh
+       jsonpath={'.items[*]'.metadata.name}) -- /bin/sh
    ```
 
 3. Fetch a JWT SVID from the identity provider on AWS and save the token from the JWT SVID into a file on the client container called `token`:


### PR DESCRIPTION
- Replaces the reference of `verify_subject_alt_name` (deprecated in new versions of Envoy) by `match_subject_alt_names` on the Envoy guide.
- Updates references to the SPIRE Server pod on some examples to the correct pod name `spire-server-0`
- Updates examples of `kubectl exec` command to include the double dash `(--)` that separates the arguments from the kubectl arguments.