### PR TITLE
Update link to java-spiffe library

### DIFF
--- a/content/spire/try/spiffe-library-usage-examples.md
+++ b/content/spire/try/spiffe-library-usage-examples.md
@@ -28,7 +28,7 @@ See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe/tree
 
 # Java
 
-See the [java-spiffe library GitHub page](https://github.com/spiffe/java-spiffe/tree/v2-api) for more information about the SPIFFE Java library. 
+See the [java-spiffe library GitHub page](https://github.com/spiffe/java-spiffe) for more information about the SPIFFE Java library. 
 
 * [Federation and TCP Support](https://github.com/spiffe/spiffe-example/tree/master/java-spiffe-federation-jboss)
 


### PR DESCRIPTION
java-spiffe v2 has graduated to be the main version of java-spiffe.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>