### PR TITLE
Fixes Slack URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,7 +23,7 @@ spire = "**SPIRE**, the SPIFFE Runtime Environment, is an extensible system that
 
 [params.socialmedia]
 twitter       = "SPIFFEio"
-slack         = "https://slack.spiffe.io/"
+slack         = "https://spiffe.slack.com/"
 medium        = "https://blog.spiffe.io/"
 github        = "https://github.com/spiffe"
 stackoverflow = "https://stackoverflow.com/questions/tagged/spiffe"

--- a/content/docs/latest/spiffe/get-involved.md
+++ b/content/docs/latest/spiffe/get-involved.md
@@ -12,7 +12,7 @@ SPIFFE is guided by a small but very active community of passionate software eng
 
 ## Join the Community
 
-* **Slack** --- Most real-time discussions happen on SPIFFE's Slack channels at https://spiffe.slack.com. You can join [here](https://slack.spiffe.io/).
+* **Slack** --- Most real-time discussions happen on SPIFFE's Slack channels at https://spiffe.slack.com.
 
 * **Mailing lists** --- Announcements occur in the SPIFFE [Google Group](https://groups.google.com/a/spiffe.io/forum/#!forum/announce). There is also a [users](https://groups.google.com/a/spiffe.io/forum/#!forum/user-discussion) and [developers](https://groups.google.com/a/spiffe.io/forum/#!forum/dev-discussion) list.
 


### PR DESCRIPTION
It seems like there used to be some sort of redirect or landing page for the subdomain `slack.spiffe.io`, but that isn't working anymore.
This PR changes the URL of the Slack button shown at the top right of the website.

Thanks @sanderson042 for the diff.

Signed-off-by: Maximiliano Churichi <maximiliano.churichi@hpe.com>