### PR TITLE
Fixes Table of Content on Downloads page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,9 @@ canonifyurls = true
 googleAnalytics = "UA-99605331-1"
 enableGitInfo = true
 
+[markup]
+  [markup.tableOfContents]
+    startLevel = 1
 
 [params]
 acronym = "Secure Production Identity Framework for Everyone"


### PR DESCRIPTION
Fixes an issue that make Hugo generates TOCs starting at `H2` (or `##` in markdown). We want to generate TOCs starting at H1s.

Preview deploy: https://deploy-preview-166--spiffe.netlify.app/downloads/

Signed-off-by: Maximiliano Churichi <maximiliano.churichi@hpe.com>