### PR TITLE
Fixes docs subsite heading spacing

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -120,6 +120,9 @@ figure
 
 .article
 
+  .hero-body
+    padding: 0 !important
+
   .content
 
     h1:not(:first-child)


### PR DESCRIPTION
Fixes extra spacing accidentally added in the docs sub-site's headings

Preview here: https://deploy-preview-178--spiffe.netlify.app/docs/latest/spiffe/overview/
See difference in the title "SPIFFE Overview" here: https://spiffe.io/docs/latest/spiffe/overview/

Signed-off-by: Maximiliano Churichi <maximiliano.churichi@hpe.com>