### PR TITLE
Widen SPIRE concepts.md graphics for text legibility

### DIFF
--- a/content/docs/latest/spire/understand/concepts.md
+++ b/content/docs/latest/spire/understand/concepts.md
@@ -20,13 +20,13 @@ This section describes the architecture and components of SPIRE, walks you throu
 
 A SPIRE deployment is composed of a SPIRE Server and one or more SPIRE Agents. A server acts as a signing authority for identities issued to a set of workloads via agents. It also maintains a registry of workload identities and the conditions that must be verified in order for those identities to be issued. Agents expose the SPIFFE Workload API locally to workloads, and must be installed on each node on which a workload is running. 
 
-{{< figure src="/img/server_and_agent.png" width="80" caption="Server and Agent" >}}
+{{< figure src="/img/server_and_agent.png" width="100" caption="Server and Agent" >}}
 
 ## All about the Server
 
 A SPIRE Server is responsible for managing and issuing all identities in its configured SPIFFE trust domain. It stores [registration entries](#workload-registration) (which specify the selectors that determine the conditions under which a particular SPIFFE ID should be issued) and signing keys, uses [node attestation](#node-attestation) to authenticate agents' identities automatically, and creates SVIDs for workloads when requested by an authenticated agent.
 
-{{< figure src="/img/server.png" width="80" caption="The SPIRE Server" >}}
+{{< figure src="/img/server.png" width="100" caption="The SPIRE Server" >}}
 
 The behavior of the server is determined through a series of plugins. SPIRE comes with several plugins included, but additional plugins can be built to extend SPIRE for specific use cases. Types of plugins include:
 
@@ -50,7 +50,7 @@ A SPIRE Agent runs on every node on which an identified workload runs. The agent
 * exposes the SPIFFE Workload API to workloads on node and attests the identity of workloads that call it  
 * provides the identified workloads with their SVIDs
 
-{{< figure src="/img/agent.png" width="80" caption="The SPIRE Agent" >}}
+{{< figure src="/img/agent.png" width="100" caption="The SPIRE Agent" >}}
 
 The agent’s main components include:
 
@@ -139,7 +139,7 @@ Node selectors are not required for node attestation unless you are [mapping wor
 
 The following diagram illustrates the steps in node attestation. In this illustration, the underlying platform is AWS:
 
-{{< figure src="/img/node_attestation.png" width="80" caption="Node Attestation" >}}
+{{< figure src="/img/node_attestation.png" width="100" caption="Node Attestation" >}}
 
 #### Summary of Steps: Node Attestation
 
@@ -190,7 +190,7 @@ While both agents and servers play a role in node attestation, only agents are i
 
 The following diagram illustrates the steps in workload attestation:
 
-{{< figure src="/img/workload_attestation.png" width="80" caption="Workload Attestation" >}}
+{{< figure src="/img/workload_attestation.png" width="100" caption="Workload Attestation" >}}
 
 #### Summary of Steps: Workload Attestation
 


### PR DESCRIPTION
The text in some of the graphics is too small to read at 80% width, so I increased the width to 100%.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>