### PR TITLE
SPIFFE book changes

### DIFF
--- a/content/book/index.html
+++ b/content/book/index.html
@@ -23,13 +23,21 @@ layout: centered
             help keep systems secure.
         </p>
         <p>
-            This book strives to distill the experience from the foremost experts on SPIFFE and SPIRE to provide a
-            deep understanding of the identity problem and how to solve it. With these projects, developers and
-            operators can build software using new infrastructure technologies while allowing security teams to step
+            This book strives to distill the experience from the foremost security experts and SPIFFE community members
+            to provide a deep understanding of the identity problem and how to solve it. With these projects, developers
+            and operators can build software using new infrastructure technologies while allowing security teams to step
             back from expensive and time-consuming manual security processes.
         </p>
+        <p>
+            This book was produced using the Book Sprints methodology (<a target="_blank"
+                href="https://www.booksprints.net">www.booksprints.net</a>). The authors wrote the book
+            during an intensive collaboration process conducted online over two weeks. Authors are Daniel Feldman, Emily
+            Fox, Evan Gilman, Ian Haken, Frederick Kautz, Umair Khan, Max Lambrecht, Brandon Lum, Agust&iacute;n
+            Mart&iacute;nez Fay&oacute;, Eli Nesterov, Andres Vega, and Michael Wardrop.
+        </p>
 
-        <a class="button is-black" target="_blank" href="/Solving-the-bottom-turtle-SPIFFE-Book.pdf">
+        <a class="button is-black" target="_blank"
+            href="https://thebottomturtle.io/Solving-the-bottom-turtle-SPIFFE-SPIRE-Book.pdf">
             <span class="icon">
                 <i class="fas fa-book"></i>
             </span>
@@ -39,7 +47,7 @@ layout: centered
         </a>
     </div>
     <div class="column">
-        <a target="_blank" href="/Solving-the-bottom-turtle-SPIFFE-Book.pdf">
+        <a target="_blank" href="https://thebottomturtle.io/Solving-the-bottom-turtle-SPIFFE-SPIRE-Book.pdf">
             <img src="../img/book_cover.png" alt="Book cover" class="book-cover big">
         </a>
     </div>

--- a/content/book/index.html
+++ b/content/book/index.html
@@ -29,11 +29,10 @@ layout: centered
             back from expensive and time-consuming manual security processes.
         </p>
         <p>
-            This book was produced using the Book Sprints methodology (<a target="_blank"
-                href="https://www.booksprints.net">www.booksprints.net</a>). The authors wrote the book
-            during an intensive collaboration process conducted online over two weeks. Authors are Daniel Feldman, Emily
-            Fox, Evan Gilman, Ian Haken, Frederick Kautz, Umair Khan, Max Lambrecht, Brandon Lum, Agust&iacute;n
-            Mart&iacute;nez Fay&oacute;, Eli Nesterov, Andres Vega, and Michael Wardrop.
+            The authors wrote the book during an intensive collaboration process conducted online over two weeks using
+            the Book Sprints methodology. Authors are Daniel Feldman, Emily Fox, Evan Gilman, Ian Haken, Frederick
+            Kautz, Umair Khan, Max Lambrecht, Brandon Lum, Agust&iacute;n Mart&iacute;nez Fay&oacute;, Eli Nesterov,
+            Andr&eacute;s Vega, and Michael Wardrop.
         </p>
 
         <a class="button is-black" target="_blank"

--- a/layouts/partials/home/book.html
+++ b/layouts/partials/home/book.html
@@ -4,8 +4,8 @@
       <div class="columns is-vcentered">
         <div class="column is-half">
           <p class="is-size-5 is-size-6-mobile">
-            In this book, experts on SPIFFE and SPIRE provide a deep understanding of the identity problem and how to
-            solve it. &#8226; <strong><a href="book/">Read more</a></strong>
+            In this book, security experts and SPIFFE community members provide a deep understanding of the identity
+            problem and how to solve it. &#8226; <strong><a href="book/">Read more</a></strong>
           </p>
         </div>
         <div class="column stretch">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -56,10 +56,6 @@
         <a class="navbar-item has-text-weight-bold" href="/docs/latest/">
           Documentation
         </a>
-        
-        <a class="navbar-item has-text-weight-bold" href="/book">
-          Get the Book
-        </a>
         {{- end -}}
 
         <div class="navbar-item">


### PR DESCRIPTION
Changes some wording on the Book landing page and home page.
Removes the book hosted in this repo and points to its new location.
Removes the "Get the Book" button on the top nav bar.

Preview: https://deploy-preview-186--spiffe.netlify.app/
Book landing page: https://deploy-preview-186--spiffe.netlify.app/book/

Signed-off-by: Maximiliano Churichi <maximiliano.churichi@hpe.com>
