### PR TITLE
Adds support for images in reference-style

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -2,8 +2,9 @@
 {{ $caption := .Get "caption" | markdownify }}
 {{ $width   := .Get "width" | default 50 }}
 {{ $alt     := cond (isset .Params "caption") $caption (.Get "alt" | markdownify) }}
+{{ $title   := .Get "title" | markdownify }}
 <figure class="figure">
-  <img src="{{ $src }}" width="{{ $width }}%">
+  <img src="{{ $src }}" width="{{ $width }}%" alt="{{ $alt }}" title="{{ $title }}">
 
   {{ with $caption }}
   <figcaption class="has-text-weight-light">

--- a/pull_external.py
+++ b/pull_external.py
@@ -9,8 +9,11 @@ from pathlib import Path
 
 CHECKOUT_DIR = "checkouts"
 GIT_CLONE_CMD = "git clone {{}} ./{}/{{}}/{{}}".format(CHECKOUT_DIR)
+MARKDOWN_IMAGE_REFERENCE_STYLE_OPENING = "["
 RE_EXTRACT_TITLE: Pattern[str] = re.compile("([#\s]*)(?P<title>.*)")
-RE_EXTRACT_IMAGES: Pattern[str] = re.compile("\!\[(?P<alt>.*)\]\((?P<url>.*)\)")
+RE_EXTRACT_IMAGES: Pattern[str] = re.compile(
+    "\!\[(?P<alt>.*)\](?P<style>[\(\[])(?P<url>.*)[\)\]]"
+)
 RE_EXTRACT_LINKS: Pattern[str] = re.compile(
     "\[(?P<alt>[^\]]*)\]\((?P<rel>[\.\/]*)(?P<url>(?P<domain>https?:\/\/[a-zA-Z\.0-9-]+)?(?!#)\S+)\)"
 )
@@ -233,6 +236,15 @@ def _process_content(
     def repl_images(m: Match[str]):
         url = m.group("url")
         alt = m.group("alt")
+        style = m.group("style")
+        title = None
+
+        if style == MARKDOWN_IMAGE_REFERENCE_STYLE_OPENING:
+            image_reference_regex = '\[{}\]: *(?P<url>.*) "(?P<title>.*)"'.format(url)
+            ref_match = re.search(image_reference_regex, m.string)
+            url = ref_match.group("url")
+            title = ref_match.group("title")
+
         new_url = _copy_asset(
             url_path=url,
             abs_path_to_source_dir=abs_path_to_source_dir,
@@ -240,8 +252,8 @@ def _process_content(
             repo_owner=repo_owner,
             repo_name=repo_name,
         )
-        figure = '{{{{< figure src="{}" caption="{}" width="100" >}}}}'.format(
-            new_url, alt
+        figure = '{{{{< figure src="{}" alt="{}" title="{}" width="100" >}}}}'.format(
+            new_url, alt, title
         )
         return figure
 

--- a/pull_external.py
+++ b/pull_external.py
@@ -97,34 +97,6 @@ def _clone_repos(repos: List[str]):
         os.system(cmd)
 
 
-# TODO: This is currently not being used
-# def pull_directories(yaml_external: dict):
-#     content: dict
-#     for target_dir, content in yaml_external.items():
-#         pull_dir = content.get("pullDir", None)
-#         if not pull_dir:
-#             continue
-
-#         # abs_target_path = get_abs_dir_path(target_dir)
-#         repo_owner, repo_name = get_canonical_repo_from_url(content.get("source"))
-#         repo_checkout_base_path = os.path.join(CHECKOUT_DIR, repo_owner, repo_name)
-#         repo_checkout_pull_path = os.path.join(repo_checkout_base_path, pull_dir)
-
-#         for root, _, files in os.walk(repo_checkout_pull_path):
-#             for file in files:
-#                 relative_path = os.path.join(
-#                     root[len(repo_checkout_pull_path) + 1 :], file
-#                 )
-#                 copy_file(
-#                     base_src_path=repo_checkout_base_path,
-#                     pull_dir=pull_dir,
-#                     rel_file_path=relative_path,
-#                     target_dir=target_dir,
-#                     transform_file=content.get("transform", {}).get(file, None),
-#                     remove_heading=True,
-#                 )
-
-
 def _pull_files(yaml_external: dict) -> List[str]:
     generated_files: List[str] = []
     content: dict


### PR DESCRIPTION
Currently, only [inline style](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#images) was supported for images in pulled in Markdown content.
This PR adds support for images in reference-style. It also adds support for `alt` and `title` properties.