### PR TITLE
Fixes spire-latest shortcode to use GitHub's Latest Release API

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -20,8 +20,8 @@ The table [below](#spire-releases) lists the available releases for [SPIRE](/doc
 
 Starting with SPIRE v0.10.0, a `spire-extras` tarball is available that contains the following binaries for Linux x86_64 operating systems:
 
-* [OIDC Discovery Provider](https://github.com/spiffe/spire/blob/master/support/oidc-discovery-provider/README.md)
-* [Kubernetes Workload Registrar](https://github.com/spiffe/spire/blob/master/support/k8s/k8s-workload-registrar/README.md)
+* [OIDC Discovery Provider](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/support/oidc-discovery-provider/README.md)
+* [Kubernetes Workload Registrar](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/support/k8s/k8s-workload-registrar/README.md)
 
 ## SPIRE Releases
 

--- a/layouts/shortcodes/releases.html
+++ b/layouts/shortcodes/releases.html
@@ -1,6 +1,7 @@
-{{- $displayReleases  := ne (getenv "HIDE_RELEASES") "true" }}
-{{- $spireReleasesUrl := "https://api.github.com/repos/spiffe/spire/releases" }}
-{{- $downloadUrl      := "https://github.com/spiffe/spire/releases/download" }}
+{{- $displayReleases       := ne (getenv "HIDE_RELEASES") "true" }}
+{{- $spireReleasesUrl      := "https://api.github.com/repos/spiffe/spire/releases" }}
+{{- $spireLatestReleaseUrl := "https://api.github.com/repos/spiffe/spire/releases/latest" }}
+{{- $downloadUrl           := "https://github.com/spiffe/spire/releases/download" }}
 
 {{- if $displayReleases }}
 <table class="is-downloads-table">
@@ -18,9 +19,10 @@
     </tr>
   </thead>
   <tbody>
-    {{- $releases         := getJSON $spireReleasesUrl }}
-    {{- range $releases }}
-    {{- $latest           := (index $releases 0).tag_name }}
+    {{- $releases         := sort (getJSON $spireReleasesUrl) "created_at" "desc" }}
+    {{- $latestRelease    := getJSON $spireLatestReleaseUrl }}
+    {{- $latest           := $latestRelease.tag_name }}
+    {{- range $releases -}}
     {{- $hasExtras        := (index .assets 2).name }}
     {{- $clipboardButtons := .Site.Params.downloads.buttons.clipboard }}
     {{- $downloadButtons  := .Site.Params.downloads.buttons.download }}

--- a/layouts/shortcodes/spire-latest.html
+++ b/layouts/shortcodes/spire-latest.html
@@ -1,15 +1,14 @@
 {{- $displayReleases  := ne (getenv "HIDE_RELEASES") "true" }}
 {{- if $displayReleases }}
-  {{- $releasesUrl   := "https://api.github.com/repos/spiffe/spire/releases" }}
-  {{- $releases      := getJSON $releasesUrl }}
-  {{- $latestTag     := (index $releases 0).tag_name }}
+  {{- $latestReleaseUrl := "https://api.github.com/repos/spiffe/spire/releases/latest" }}
+  {{- $latest           := getJSON $latestReleaseUrl }}
 
   {{- if eq (.Get 0) "tag" }}
-    {{- $latestTag -}}
+    {{- $latest.tag_name -}}
   {{- else if eq (.Get 0) "version" -}}
-    {{- index (findRE "([0-9.]+)" $latestTag) 0 }}
+    {{- index (findRE "([0-9.]+)" $latest.tag_name) 0 }}
   {{- else if eq (.Get 0) "tarball" -}}
-    {{- (index (index $releases 0).assets 0).name -}}
+    {{- (index $latest.assets 0).name -}}
   {{- end -}}
 
 {{- else -}}


### PR DESCRIPTION
Fixes #210 

Previews:
- https://deploy-preview-211--spiffe.netlify.app/docs/latest/deploying/install-server/
- https://deploy-preview-211--spiffe.netlify.app/docs/latest/deploying/install-agents/
- https://deploy-preview-211--spiffe.netlify.app/downloads/

Signed-off-by: Maximiliano Churichi <maximiliano.churichi@hpe.com>
