### PR TITLE
Update Envoy config example using new default agent socket path

### DIFF
--- a/content/docs/latest/microservices/envoy.md
+++ b/content/docs/latest/microservices/envoy.md
@@ -42,7 +42,7 @@ clusters:
     http2_protocol_options: {}
     hosts:
     - pipe:
-      path: /tmp/agent.sock
+      path: /tmp/spire-agent/public/api.sock
 ```
 
 The `connect_timeout` influences how fast Envoy will be able to respond if the SPIRE Agent is not running when Envoy is started or if the SPIRE Agent is restarted.


### PR DESCRIPTION
The default agent socket path has changed in [#2075](https://github.com/spiffe/spire/pull/2075).

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>