### PR TITLE
Updates SPIFFE libraries page

### DIFF
--- a/content/docs/latest/deploying/libraries.md
+++ b/content/docs/latest/deploying/libraries.md
@@ -19,11 +19,11 @@ See the [c-spiffe library GitHub page](https://github.com/spiffe/c-spiffe) for m
 
 # Go
 
-See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe/tree/master/v2) for more information about the SPIFFE Go library. 
+See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe/tree/main/v2) for more information about the SPIFFE Go library. 
 
-* [SPIFFE to SPIFFE authentication using X.509 SVIDs](https://github.com/spiffe/go-spiffe/tree/master/v2/examples/spiffe-tls)
+* [SPIFFE to SPIFFE authentication using X.509 SVIDs](https://github.com/spiffe/go-spiffe/tree/main/v2/examples/spiffe-tls)
 
-* [SPIFFE to SPIFFE authentication using JWT SVIDs](https://github.com/spiffe/go-spiffe/tree/master/v2/examples/spiffe-jwt-using-proxy)
+* [SPIFFE to SPIFFE authentication using JWT SVIDs](https://github.com/spiffe/go-spiffe/tree/main/v2/examples/spiffe-jwt-using-proxy)
 
 # Java
 

--- a/content/docs/latest/deploying/libraries.md
+++ b/content/docs/latest/deploying/libraries.md
@@ -27,7 +27,4 @@ See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe/tree
 
 # Java
 
-See the [java-spiffe library GitHub page](https://github.com/spiffe/java-spiffe) for more information about the SPIFFE Java library. 
-
-* [Federation and TCP Support](https://github.com/spiffe/spiffe-example/tree/master/java-spiffe-federation-jboss)
-
+See the [java-spiffe library GitHub page](https://github.com/spiffe/java-spiffe) for more information about the SPIFFE Java library.


### PR DESCRIPTION
- Removes java-spiffe example that is no longer available and it has been deprecated. (cc @maxlambrecht )
- Updates go-spiffe default branch

Signed-off-by: Maximiliano Churichi <maximiliano.churichi@hpe.com>
