### PR TITLE
Replace David Langhorst with Andres Gomez Coronel as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sanderson042 @mchurichi @ajessup @drrt @evan2645 @umairmkhan
+* @sanderson042 @mchurichi @ajessup @Andres-GC @evan2645 @umairmkhan


### PR DESCRIPTION
@drrt has expressed he's not interested in continuing as a spiffe.io code owner anymore. Thanks Dave for all the hard work you have been putting during the last few years!

I propose to add Andres Gomez Coronel in his place. Tagging @Andres-GC for consent purposes.

Signed-off-by: Maximiliano Churichi <maximiliano.churichi@hpe.com>