### PR TITLE
Fix broken URLs discovered by new link checker

### DIFF
--- a/content/docs/latest/deploying/configuring.md
+++ b/content/docs/latest/deploying/configuring.md
@@ -65,7 +65,7 @@ Your choice of node attestation method determines which node-attestor plugins yo
 
 To issue identities to workloads running in a Kubernetes cluster, it is necessary to deploy a SPIRE Agent to each node in that cluster that is running a workload ([read more](/docs/latest/spire/installing/install-agents/#installing-spire-agents-on-kubernetes) on how to install SPIRE Agents on Kubernetes).
 
-Service Account Tokens can be validated using the Kubernetes [Token Review API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#tokenreview-v1-authentication-k8s-io). Because of this, the SPIRE Server does not itself need to be running on Kubernetes, and a single SPIRE Server may support agents running on multiple Kubernetes clusters with PSAT attestation enabled.
+Service Account Tokens can be validated using the Kubernetes [Token Review API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/). Because of this, the SPIRE Server does not itself need to be running on Kubernetes, and a single SPIRE Server may support agents running on multiple Kubernetes clusters with PSAT attestation enabled.
 
 ### Projected Service Account Tokens
 

--- a/content/docs/latest/deploying/libraries.md
+++ b/content/docs/latest/deploying/libraries.md
@@ -15,7 +15,8 @@ The following code samples demonstrate how to use the libraries to establish and
 
 # C, C++
 
-See the [c-spiffe library GitHub page](https://github.com/HewlettPackard/c-spiffe) for more information about the SPIFFE C/C++ library, which is under development in 2021. This library replaces an earlier c-spiffe library that was archived.
+See the [c-spiffe library GitHub page](https://github.com/HewlettPackard/c-spiffe) for more information about a SPIFFE C/C++ library. This library is not yet part of the official SPIFFE repo and is still under development in June 2021. An earlier official c-spiffe library became out-of-date and was archived.
+
 
 # Go
 

--- a/content/docs/latest/deploying/libraries.md
+++ b/content/docs/latest/deploying/libraries.md
@@ -13,9 +13,9 @@ You can use one of the following libraries to fetch SVIDs and trust bundles from
 
 The following code samples demonstrate how to use the libraries to establish and maintain SPIFFE-enabled connections transparently between applications.
 
-# C++
+# C, C++
 
-See the [c-spiffe library GitHub page](https://github.com/spiffe/c-spiffe) for more information about the SPIFFE C++ library. 
+See the [c-spiffe library GitHub page](https://github.com/HewlettPackard/c-spiffe) for more information about the SPIFFE C/C++ library, which is under development in 2021. This library replaces an earlier c-spiffe library that was archived.
 
 # Go
 


### PR DESCRIPTION
* In configuring.md, replaced link to k8s Token Review API with
  different location that doesn't include a version number

* In libraries.md, replaced link to archived c-spiffe library with new
  c-spiffe library under development by HPE

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>