### PR TITLE
Update links to spiffe's GitHub master branch to main instead

### DIFF
--- a/content/docs/latest/deploying/svids.md
+++ b/content/docs/latest/deploying/svids.md
@@ -19,13 +19,13 @@ Developers coding a new workload that needs to interact with SPIFFE can interact
 
 * Generate short-lived keys and certificates on behalf of the workload, specifically:
  * A private key tied to that SPIFFE ID that can be used to sign data on behalf of the workload. 
- * A corresponding short-lived X.509 certificate - an [X509-SVID](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md). This can be used to establish TLS or otherwise authenticate to other workloads.
+ * A corresponding short-lived X.509 certificate - an [X509-SVID](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md). This can be used to establish TLS or otherwise authenticate to other workloads.
  * A set of certificates – known as a [trust bundle](/docs/latest/spiffe/concepts/#trust-bundle) – that a workload can use to verify an X.509-SVID presented by another workload in the same trust domain or a federated trust domain.
-* Generate or validate JSON Web Tokens ([JWT-SVIDs](https://github.com/spiffe/spiffe/blob/master/standards/JWT-SVID.md)) issued on behalf of the workload or another workload in the same trust domain or a federated trust domain.
+* Generate or validate JSON Web Tokens ([JWT-SVIDs](https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md)) issued on behalf of the workload or another workload in the same trust domain or a federated trust domain.
 
 The Workload API doesn't require any explicit authentication (such as a secret). Rather, the SPIFFE specification leaves it to implementation of the SPIFFE Workload API to determine how to authenticate the workload. In the case of SPIRE, this is achieved by inspecting the Unix kernel metadata collected by the SPIRE Agent when a workload calls the API.
 
-The API is a gRPC API, derived [from a protobuf](https://github.com/spiffe/go-spiffe/blob/master/proto/spiffe/workload/workload.proto). The [gRPC project](https://grpc.io/) provides tools to generate client libraries from a protobuf in a variety of languages.
+The API is a gRPC API, derived [from a protobuf](https://github.com/spiffe/go-spiffe/blob/main/proto/spiffe/workload/workload.proto). The [gRPC project](https://grpc.io/) provides tools to generate client libraries from a protobuf in a variety of languages.
 
 ## Working with SVIDs in Go 
 

--- a/content/docs/latest/spiffe-about/get-involved.md
+++ b/content/docs/latest/spiffe-about/get-involved.md
@@ -25,12 +25,12 @@ SPIFFE is guided by a small but very active community of passionate software eng
 
 You can contribute to SPIFFE and SPIRE by filing issues and submitting pull requests on GitHub. See these contribution guidelines for details such as GitHub etiquette and coding conventions:
 
-* [SPIFFE contribution guidelines](https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md)
+* [SPIFFE contribution guidelines](https://github.com/spiffe/spiffe/blob/main/CONTRIBUTING.md)
 * [SPIRE contribution guidelines](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/CONTRIBUTING.md)
 
 While anyone is welcome to propose contributions via pull requests, we strongly encourage significant contributions - particularly those that might require a significant change to core components - to be first discussed and a high level design agreed upon with the appropriate SIGs or WGs (see above).
 
-Day to day contributions are vetted by the project's maintainers. Overall project direction, guidance and conflict resolution is overseen by the projects' Technical Steering Committee. Full details on this process can be found [in the project GOVERNANCE page](https://github.com/spiffe/spiffe/blob/master/GOVERNANCE.md).
+Day to day contributions are vetted by the project's maintainers. Overall project direction, guidance and conflict resolution is overseen by the projects' Technical Steering Committee. Full details on this process can be found [in the project GOVERNANCE page](https://github.com/spiffe/spiffe/blob/main/GOVERNANCE.md).
 
 ## SPIFFE and SPIRE Branding Media Library
 

--- a/content/docs/latest/spiffe-about/spiffe-concepts.md
+++ b/content/docs/latest/spiffe-about/spiffe-concepts.md
@@ -33,7 +33,7 @@ SPIFFE IDs are a [Uniform Resource Identifier (URI)](https://tools.ietf.org/html
 
 The _workload identifier_ uniquely identifies a specific workload within a [trust domain](#trust-domain).
 
-The [SPIFFE specification](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE.md) describes in detail the format and use of SPIFFE IDs.
+The [SPIFFE specification](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE.md) describes in detail the format and use of SPIFFE IDs.
 
 ## Trust Domain
 
@@ -49,7 +49,7 @@ An SVID contains a single SPIFFE ID, which represents the identity of the servic
 
 As tokens are susceptible to _replay attacks_, in which an attacker that obtains the token in transit can use it to impersonate a workload, it is advised to use X.509-SVIDs whenever possible. However, there may be some situations in which the only option is the JWT token format, for example, when your architecture has an L7 proxy or load balancer between two workloads.
 
-For detailed information on the SVID, see the [SVID specification](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md).
+For detailed information on the SVID, see the [SVID specification](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md).
 
 ## SPIFFE Workload API
 

--- a/layouts/shortcodes/specs.html
+++ b/layouts/shortcodes/specs.html
@@ -1,5 +1,5 @@
 {{- $documents := .Site.Data.spec.documents }}
-{{- $rootUrl   := "https://github.com/spiffe/spiffe/blob/master/standards" }}
+{{- $rootUrl   := "https://github.com/spiffe/spiffe/blob/main/standards" }}
 <ul>
   {{- range $documents }}
   {{- $url := printf "%s/%s" $rootUrl .filename }}


### PR DESCRIPTION
Currently they all redirect to the main branch, but we can just go there directly