### PR TITLE
Removing invalid action from AWS S3 Policy

### DIFF
--- a/content/docs/latest/keyless/oidc-federation-aws.md
+++ b/content/docs/latest/keyless/oidc-federation-aws.md
@@ -232,8 +232,7 @@ The following simple AWS IAM policy governs access to the S3 bucket used in this
                    "s3:GetAccountPublicAccessBlock",
                    "s3:ListAllMyBuckets",
                    "s3:ListJobs",
-                   "s3:CreateJob",
-                   "s3:HeadBucket"
+                   "s3:CreateJob"
                ],
                "Resource": "*"
            },


### PR DESCRIPTION
When creating Policy in tutorial AWS is throwing error "Ln 13, Col 16Invalid Action: The action s3:HeadBucket does not exist. Did you mean s3:ListBucket? The API called HeadBucket authorizes against the IAM action s3:ListBucket."
Policy works by removing HeadBucket Action

Signed-off-by: Philip Corney <Phil.Corney@gmail.com>