### PR TITLE
Announce project as graduated

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -237,6 +237,14 @@ body.is-home-page
   +tablet
     width: 15%
 
+section.news
+  padding: 5px
+  background-color: $spiffe-green
+  color: $grey-dark
+  a
+    text-decoration: underline
+    color: $grey-dark
+
 section.newsbar
   background: #000
   padding: 12px

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
 {{ partial "home/hero.html" . }}
 {{ partial "home/use-cases.html" . }}
+{{ partial "home/news.html" . }}
 {{ partial "home/newsbar.html" . }}
 {{ partial "home/what-is.html" . }}
 {{ partial "home/book.html" . }}

--- a/layouts/partials/home/cncf.html
+++ b/layouts/partials/home/cncf.html
@@ -2,7 +2,7 @@
 <section class="section has-text-centered">
   <div class="container">
     <p class="is-size-5 is-size-6-mobile has-text-weight-light">
-      SPIFFE and SPIRE are <a href="https://cncf.io" target="_blank">Cloud Native Computing Foundation</a> incubation projects
+      SPIFFE and SPIRE are graduate projects of the <a href="https://cncf.io" target="_blank">Cloud Native Computing Foundation</a>
     </p>
 
     <img class="cncf-logo" src="{{ $logo }}" alt="Cloud Native Computing Foundation logo">

--- a/layouts/partials/home/news.html
+++ b/layouts/partials/home/news.html
@@ -1,0 +1,8 @@
+<section class="news is-medium">
+    <div class="has-text-centered">
+      <div class="container">
+        <p class="is-size-5 is-size-5-mobile">
+            <strong>New!</strong> SPIFFE and SPIRE are now <a href="https://www.cncf.io/announcements/2022/09/20/spiffe-and-spire-projects-graduate-from-cloud-native-computing-foundation-incubator/">graduate projects</a> of the Cloud Native Computing Foundation
+        </p>
+    </div>
+  </section>


### PR DESCRIPTION
This PR (a) updates the text on the homepage to describe the projects as "graduate projects" of the CNCF, and (b) adds a re-usable news bar to the homepage to announce the change.