### PR TITLE
Remove references to non-existent Docker Compose resources

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -13,7 +13,6 @@ The table [below](#spire-releases) lists the available releases for [SPIRE](/doc
 * A tarball for Linux x86_64 operating systems containing:
   * The `spire-agent` and `spire-server` binaries
   * Configuration files for the SPIRE Agent and Server
-  * A [Docker Compose](https://docs.docker.com/compose) configuration that enables you to run an agent and a server simultaneously using [Docker](https://docker.com)
 * A `.txt` file containing the SHA-256 checksum for the binary tarball
 * The SPIRE source code as a zip file
 * The SPIRE source code as a tarball

--- a/external.yaml
+++ b/external.yaml
@@ -5,9 +5,9 @@ try:
     transform:
         SPIRE101.md:
             frontMatter:
-                title: Quickstart for Docker Compose
-                short: Quickstart for Docker Compose
-                description: Quickly get SPIRE up and running on Docker Compose
+                title: Quickstart for Docker
+                short: Quickstart for Docker
+                description: Quickly get SPIRE up and running on Docker
                 kind: try
                 weight: 55
                 aliases:


### PR DESCRIPTION
**Description of the change**
References https://github.com/spiffe/spire/blob/main/doc/SPIRE101.md, saying it has instructions on how to get started using SPIRE with Docker Compose. But it doesn't. It does have instructions for building Docker images from source.
