### PR TITLE
Fixes broken build

### DIFF
--- a/external.yaml
+++ b/external.yaml
@@ -46,7 +46,7 @@ deploying:
         - doc/using_spire.md
         - doc/spire_agent.md
         - doc/spire_server.md
-        - doc/telemetry_config.md
+        - doc/telemetry/telemetry_config.md
     transform:
         using_spire.md:
             frontMatter:


### PR DESCRIPTION
<!--
Please remember to include a DCO on every commit (`git commit -s`). This repository requires all commits to be signed-off.
https://github.com/apps/dco
-->
**Description of the change**
The build is currently trying to pull the telemetry config file from the spire repo but the file has been moved, which causes the build to break. This PR updates to pull the file from its new location.

From Netlify's logs:
```
4:43:16 PM: Traceback (most recent call last):
4:43:16 PM:   File "./pull_external.py", line 384, in <module>
4:43:16 PM:     main()
4:43:16 PM:   File "./pull_external.py", line 51, in main
4:43:16 PM:     generated_files = _pull_files(yaml_external)
4:43:16 PM:   File "./pull_external.py", line 204, in _pull_files
4:43:16 PM:     generated_files = _process_files(yaml_external)
4:43:16 PM:   File "./pull_external.py", line 187, in _process_files
4:43:16 PM:     abs_path_to_target_file = _copy_file(
4:43:16 PM:   File "./pull_external.py", line 245, in _copy_file
4:43:16 PM:     content, heading = _get_file_content(abs_path_to_source_file, remove_heading)
4:43:16 PM:   File "./pull_external.py", line 99, in _get_file_content
4:43:16 PM:     with open(filename, "r") as f:
4:43:16 PM: FileNotFoundError: [Errno 2] No such file or directory: '/opt/build/repo/checkouts/spiffe/spire/doc/telemetry_config.md'
4:43:16 PM: make: *** [Makefile:55: pull-external-content] Error 1
```

**Which issue this PR fixes**
<!-- optional. `Fixes #<issue number>` format will close an issue when this PR is merged -->
N/A