### PR TITLE
Updates link to Teleport Workload Identity

### DIFF
--- a/data/users.yaml
+++ b/data/users.yaml
@@ -17,7 +17,7 @@ issuers:
     logo: Kubernetes_logo.png
   - name: Teleport Workload Identity
     logo: teleport_logo.svg
-    link: https://goteleport.com/docs/machine-id/workload-identity/
+    link: https://goteleport.com/platform/teleport-workload-identity/
 consumers:
   - name: The Envoy proxy
     description: Customers can use SPIFFE IDs to establish [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication#mTLS) connections between Envoy proxies


### PR DESCRIPTION
**Description of the change**

Since this original link was added, we've introduced a landing page on our site for Teleport Workload Identity. This is probably a more suitable place to link people who are interested - hence this PR.

**Which issue this PR fixes**

No issue.