### PR TITLE
Remove mentions of the k8s_sat node attestor 

### DIFF
--- a/content/docs/latest/deploying/configuring.md
+++ b/content/docs/latest/deploying/configuring.md
@@ -69,9 +69,13 @@ Service Account Tokens can be validated using the Kubernetes [Token Review API](
 
 ### Projected Service Account Tokens
 
-Node attestation using Kubernetes [Projected Service Account Tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) (PSATs) allows a SPIRE Server to verify the identity of a SPIRE Agent running on a Kubernetes Cluster. Projected Service Account Tokens provide additional security guarantees over traditional Kubernetes Service Account Tokens and when supported by a Kubernetes cluster, PSAT is the recommended attestation strategy.
+Node attestation using Kubernetes [Projected Service Account Tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) (PSATs) allows a SPIRE Server to verify the identity of a SPIRE Agent running on a Kubernetes Cluster.
 
 To use PSAT Node Attestation, configure enable the PSAT Node Attestor plugin on the [SPIRE Server](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_server_nodeattestor_k8s_psat.md) and [SPIRE Agent](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_agent_nodeattestor_k8s_psat.md).
+
+{{< info >}}
+SAT based node attestation, an earlier alternative to PSAT, is no longer supported as of SPIRE 1.12.0.
+{{< /info >}}
 
 ## Attestation of nodes running Linux {#customize-server-linux-attestation}
 

--- a/content/docs/latest/deploying/configuring.md
+++ b/content/docs/latest/deploying/configuring.md
@@ -69,21 +69,9 @@ Service Account Tokens can be validated using the Kubernetes [Token Review API](
 
 ### Projected Service Account Tokens
 
-{{< info >}}
-At the time of this writing,  projected service accounts are a relatively new feature in Kubernetes and not all deployments support them. Your Kubernetes platform documentation will tell you whether this feature is available. If your Kubernetes deployment does _not_ support Projected Service Account Tokens, you should enable Service Account Tokens instead.
-{{< /info >}}
-
 Node attestation using Kubernetes [Projected Service Account Tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) (PSATs) allows a SPIRE Server to verify the identity of a SPIRE Agent running on a Kubernetes Cluster. Projected Service Account Tokens provide additional security guarantees over traditional Kubernetes Service Account Tokens and when supported by a Kubernetes cluster, PSAT is the recommended attestation strategy.
 
 To use PSAT Node Attestation, configure enable the PSAT Node Attestor plugin on the [SPIRE Server](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_server_nodeattestor_k8s_psat.md) and [SPIRE Agent](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_agent_nodeattestor_k8s_psat.md).
-
-### Service Account Tokens
-
-In cases where workloads are running on Kubernetes but the Projected Service Account Token feature is not available for the cluster they are running on, SPIRE can establish trust between the Server and Agent using Service Account Tokens. Unlike when using Projected Service Account Tokens, this method requires that the SPIRE Server and SPIRE Agent both be deployed on the same Kubernetes cluster.
-
-Because the service account token does not contain claims that could be used to strongly identify the node/daemonset/pod running the agent, any container running in an allowed service account can masquerade as an agent. For this reason it is strongly recommended that agents run under a dedicated service account when using this attestation method.
-
-To use SAT Node Attestation, configure and enable the SAT Node Attestor plugin on the [SPIRE Server](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_server_nodeattestor_k8s_sat.md) and [SPIRE Agent](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_agent_nodeattestor_k8s_sat.md).
 
 ## Attestation of nodes running Linux {#customize-server-linux-attestation}
 

--- a/content/docs/latest/deploying/registering.md
+++ b/content/docs/latest/deploying/registering.md
@@ -62,7 +62,7 @@ Different selectors are available depending on the platform or architecture on w
 
 | For a list of supported selectors for this platform | Go here                                                                                                                                                                                              |
 |-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Kubernetes**                                      | The [configuration reference page for the Kubernetes Node Attestor](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_server_nodeattestor_k8s_sat.md)                       |
+| **Kubernetes**                                      | The [configuration reference page for the Kubernetes Node Attestor](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_server_nodeattestor_k8s_psat.md)                       |
 | **AWS**                                             | The [configuration reference page for the AWS Node Attestor](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_server_nodeattestor_aws_iid.md)                              |
 | **Azure**                                           | The [configuration reference page for the Azure Managed Service Identity Node Attestor](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_server_nodeattestor_azure_msi.md) |
 

--- a/content/docs/latest/try/getting-started-k8s.md
+++ b/content/docs/latest/try/getting-started-k8s.md
@@ -153,9 +153,9 @@ In order to enable SPIRE to perform workload attestation -- which allows the age
     $ kubectl exec -n spire spire-server-0 -- \
         /opt/spire/bin/spire-server entry create \
         -spiffeID spiffe://example.org/ns/spire/sa/spire-agent \
-        -selector k8s_sat:cluster:demo-cluster \
-        -selector k8s_sat:agent_ns:spire \
-        -selector k8s_sat:agent_sa:spire-agent \
+        -selector k8s_psat:cluster:demo-cluster \
+        -selector k8s_psat:agent_ns:spire \
+        -selector k8s_psat:agent_sa:spire-agent \
         -node
     ```
 

--- a/content/docs/latest/try/getting-started-k8s.md
+++ b/content/docs/latest/try/getting-started-k8s.md
@@ -231,17 +231,6 @@ $ minikube start \
 For Kubernetes versions prior to 1.17.0 the `apiserver.authorization-mode` can be specified as `apiserver.authorization-mode=RBAC`. Besides, for older versions of Kubernetes you should use `apiserver.service-account-api-audiences` configuration flag instead of `apiserver.api-audiences`.
 {{< /info >}}
 
-# Considerations For A Production Environment
-
-When deploying SPIRE in a production environment the following considerations should be made.
-
-In the [Create Server Configmap](#create-server-configmap) step: set the the cluster name in the `k8s_sat NodeAttestor` entry to the name you provide in the **agent-configmap.yaml** configuration file.
-
-If your Kubernetes cluster supports projected service account tokens, consider using the built-in 
-[Projected Service Account Token k8s Node Attestor](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_server_nodeattestor_k8s_psat.md) for authenticating the SPIRE agent to the server. Projected Service Account Tokens are more tightly scoped than regular service account tokens, and thus more secure.
-
-As configured, the SPIRE agent does not verify the identity of the Kubernetes kubelet when requesting metadata for workload attestation. For additional security, you may wish to configure the Kubernetes workload attestor to perform this verification on compatible Kubernetes distributions by setting `skip_kubelet_verification` to `false`. [Read more](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/doc/plugin_agent_workloadattestor_k8s.md)
-
 # Next steps
 
 * [Review the SPIRE Documentation](/docs/latest/spire/using/) to learn how to configure SPIRE for your environment.


### PR DESCRIPTION
**Description of the change**

The k8s_sat node attestor has been deprecated for a few releases and will be removed in 1.12.0. This remove the usage of it found in on spiffe.io.

This should only be merged after https://github.com/spiffe/spire-tutorials/pull/140 gets merged.

**Which issue this PR fixes**
fixes #325
