### PR TITLE
remove broken link to Kubernetes Workload Registrar

### DIFF
--- a/content/downloads/_index.md
+++ b/content/downloads/_index.md
@@ -21,7 +21,6 @@ The table [below](#spire-releases) lists the available releases for [SPIRE](/doc
 Starting with SPIRE v0.10.0, a `spire-extras` tarball is available that contains the following binaries for Linux x86_64 operating systems:
 
 * [OIDC Discovery Provider](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/support/oidc-discovery-provider/README.md)
-* [Kubernetes Workload Registrar](https://github.com/spiffe/spire/blob/{{< spire-latest "tag" >}}/support/k8s/k8s-workload-registrar/README.md)
 
 ## SPIRE Releases
 


### PR DESCRIPTION
<!--
Please remember to include a DCO on every commit (`git commit -s`). This repository requires all commits to be signed-off.
https://github.com/apps/dco
-->
**Description of the change**

Remove broken link.   Appears this was depreciated a couple of years ago ( ref https://github.com/spiffe/spire/pull/3853 )

**Which issue this PR fixes**

