### PR TITLE
Update commercial software table with Teleport PKI Integration support

### DIFF
--- a/content/docs/latest/spiffe-about/overview.md
+++ b/content/docs/latest/spiffe-about/overview.md
@@ -43,7 +43,7 @@ SPIFFE comprises many specifications, each providing different parts of the SPIF
 | GCP           | ✔          |          | ✔                          |              |         |                   |                 | ✔               | ✔                  | ✔                         |                    |
 | Greymatter.io | ✔          | ✔        | ✔                          | ✔            | ✔       |                   |                 | ✔               | ✔                  | ✔                         | ✔                  |
 | SPIRL         | ✔          | ✔        | ✔                          | ✔            | ✔       | ✔                 | ✔               | ✔               | ✔                  | ✔                         | ✔                  |
-| Teleport      | ✔          | ✔        | ✔                          | ✔            | ✔       | ✔                 | ✔               |                 | ✔                  | ✔                         |                    |
+| Teleport      | ✔          | ✔        | ✔                          | ✔            | ✔       | ✔                 | ✔               | ✔               | ✔                  | ✔                         |                    |
 | Venafi        | ✔          |          | ✔                          |              |         |                   |                 |                 | ✔                  | ✔                         |                    |
 
 ### Explanation of Columns - Software that Implements SPIFFE


### PR DESCRIPTION
<!--
Please remember to include a DCO on every commit (`git commit -s`). This repository requires all commits to be signed-off.
https://github.com/apps/dco
-->
**Description of the change**
With [v17.4.5](https://goteleport.com/docs/changelog/#1745-041725) Teleport supports external PKI integration. This updates the table to reflect this support.

