### PR TITLE
Add GCP Workload Identity Federation to Commercial Software grid

### DIFF
--- a/content/docs/latest/spiffe-about/overview.md
+++ b/content/docs/latest/spiffe-about/overview.md
@@ -96,11 +96,12 @@ SPIFFE enjoys a broad ecosystem, with many software projects, products, and plat
 
 ### Commercial Software that Works with SPIFFE
 
-| Software               | X.509 SVID | JWT SVID | SPIFFE Authentication | Workload API |
-|:-----------------------|:----------:|:--------:|:---------------------:|:------------:|
-| AWS IAM Roles Anywhere | ✔          |          |                       |              |
-| Greymatter.io          | ✔          | ✔        | ✔                     | ✔            |
-| VMware Secrets Manager | ✔          |          | ✔                     | ✔            |
+| Software                         | X.509 SVID | JWT SVID | SPIFFE Authentication | Workload API |
+|:---------------------------------|:----------:|:--------:|:---------------------:|:------------:|
+| AWS IAM Roles Anywhere           | ✔          |          |                       |              |
+| Greymatter.io                    | ✔          | ✔        | ✔                     | ✔            |
+| VMware Secrets Manager           | ✔          |          | ✔                     | ✔            |
+| GCP Workload Identity Federation | ✔          | ✔        |                       |              |
 
 ### Explanation of Columns - Software that Works with SPIFFE
 
@@ -108,7 +109,7 @@ X.509 SVID
 : Supports X.509 SVID-based authentication
 
 JWT SVID
-: Supports JWT SVID based authentication
+: Supports JWT SVID-based authentication
 
 SPIFFE Authentication
 : Supports federated SPIFFE authentication based on trust domain name


### PR DESCRIPTION
<!--
Please remember to include a DCO on every commit (`git commit -s`). This repository requires all commits to be signed-off.
https://github.com/apps/dco
-->
**Description of the change**

Adds GCP Workload Identity federation to the "Commercial Software that Works with SPIFFE" grid since they've added support for X509 authentication similar to AWS Roles Anywhere. They also support JWT authentication via OIDC - so I've checked that box as well.

It's not too clear to me by what we mean with "SPIFFE Authentication" - can anyone clarify?

**Which issue this PR fixes**
Fixes #336
