### PR TITLE
Remove myself from Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sanderson042 @mchurichi @ajessup @Andres-GC @evan2645 @umairmkhan @usirin @hamzaerbay @v0lkan
+* @mchurichi @ajessup @Andres-GC @evan2645 @umairmkhan @usirin @hamzaerbay @v0lkan


### PR DESCRIPTION
This PR is to remove me from the Codeowners file as part of leaving active involvement in spiffe.io. I'm responsible for much of the [noted inaction](https://github.com/spiffe/spiffe.io/pull/340) on spiffe.io PR reviews and issues. As I've moved away from active work in the zero trust field and time has passed, my interest in maintaining the docs has waned and they’ve suffered.

Now that @hamzaerbay, @usirin, and @v0lkan have stepped forward to take on the backlog of PRs and issues, it seems like a good time to say adios to the project. I wish them luck in revitalizing the SPIFFE doc set and offer a heartfelt grazie mille.

I’ve enjoyed working with my old Scytale chums, new SPIFFE SIG Community chums, and meeting various folks at SPIFFE events and online over the years. Thanks!