### PR TITLE
MVP of Ecosystem directory

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -126,3 +126,22 @@ a
   // hugging the left.
   .content
     width: 100%
+
+// Ecosystem page (content/docs/latest/spiffe-about/ecosystem.md). Scoped under
+// `.content` so these beat Bulma's `.content ul` / `.content .icon` rules on
+// specificity (the listing renders inside the docs article `.content`).
+.content
+  // Give the legend's wrapped icon/label pairs a little vertical gap on narrow
+  // screens (they sit inline with `mr-4` otherwise).
+  .ecosystem-legend .icon-text
+    margin-bottom: .25rem
+
+  // A tight, one-line-per-project list: drop the default disc bullet and 2em
+  // indent so the type icon acts as the marker.
+  .ecosystem-list
+    list-style: none
+    margin-left: 0
+
+    .icon
+      vertical-align: middle
+      margin-right: .35rem

--- a/content/docs/latest/spiffe-about/ecosystem.md
+++ b/content/docs/latest/spiffe-about/ecosystem.md
@@ -1,0 +1,17 @@
+---
+title: SPIFFE Ecosystem
+short: Ecosystem
+description: Official and community projects in the SPIFFE ecosystem
+navgroup: spiffe-about
+weight: 250
+aliases:
+    - /docs/latest/spiffe/ecosystem
+---
+
+SPIFFE is supported by a broad ecosystem of projects, ranging from the core specifications and their reference implementation through to SDKs, deployment tooling, and the many open-source and commercial platforms that issue or consume SPIFFE identities.
+
+This page collects some of the more notable projects, grouped by what they do. Each one is marked as a SPIFFE official project, a community project, or a commercial offering. The list is not exhaustive - if a project is missing, contributions are welcome via a [pull request to this site](https://github.com/spiffe/spiffe.io).
+
+{{< ecosystem >}}
+
+{{< scarf/pixels/medium-interest >}}

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -11,7 +11,7 @@
 # under and whether the SPIFFE functionality is gated behind enterprise
 # licensing. Err on the side of "commercial" if it is not clearly FOSS.
 categories:
-  - name: SPIRE and Plugins
+  - name: SPIRE & Plugins
     weight: 100
     description: SPIRE, the reference implementation of SPIFFE, along with the plugins and tooling that extend and operate it.
     projects:
@@ -60,11 +60,6 @@ categories:
         weight: 200
         link: https://github.com/spiffe/java-spiffe
         description: SPIFFE SDK for Java.
-      - name: c-spiffe
-        type: official
-        weight: 300
-        link: https://github.com/spiffe/c-spiffe
-        description: SPIFFE SDK for C and C++.
       - name: py-spiffe
         type: community
         weight: 400

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -116,7 +116,7 @@ categories:
         link: https://infisical.com/docs/documentation/platform/identities/spiffe-auth
         description: Secrets manager with support for SPIFFE authentication.
 
-  - name: Service Meshes and Proxies
+  - name: Service Meshes & Proxies
     weight: 500
     description: Service meshes and proxies that use SPIFFE identities to authenticate and secure traffic between workloads.
     projects:

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -110,6 +110,11 @@ categories:
         weight: 200
         link: https://developer.hashicorp.com/vault/docs/auth/spiffe
         description: Secrets manager with support for SPIFFE authentication.
+      - name: Infisical
+        type: commercial
+        weight: 200
+        link: https://infisical.com/docs/documentation/platform/identities/spiffe-auth
+        description: Secrets manager with support for SPIFFE authentication.
 
   - name: Service Meshes and Proxies
     weight: 500

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -1,0 +1,142 @@
+# Drives the SPIFFE Ecosystem page (content/docs/latest/spiffe-about/ecosystem.md)
+# via the {{< ecosystem >}} shortcode.
+#
+# Categories and the projects within them are both ordered by `weight`
+# (ascending). Each project's `type` selects its legend icon:
+#   official   - maintained by the SPIFFE project
+#   community  - maintained by the wider community
+#   commercial - a vendor product or managed service
+#
+# For community vs commercial. Consider what license the project is released
+# under and whether the SPIFFE functionality is gated behind enterprise
+# licensing. Err on the side of "commercial" if it is not clearly FOSS.
+categories:
+  - name: SPIRE and Plugins
+    weight: 100
+    description: SPIRE, the reference implementation of SPIFFE, along with the plugins and tooling that extend and operate it.
+    projects:
+      - name: SPIRE
+        type: official
+        weight: 100
+        link: https://github.com/spiffe/spire
+        description: The SPIFFE Runtime Environment - the reference implementation of SPIFFE, handling node and workload attestation and SVID issuance and rotation.
+      - name: SPIRE Controller Manager
+        type: official
+        weight: 200
+        link: https://github.com/spiffe/spire-controller-manager
+        description: Manages SPIRE registration entries and federation relationships from Kubernetes custom resources.
+      - name: SPIRE Hardened Helm Charts
+        type: official
+        weight: 300
+        link: https://github.com/spiffe/helm-charts-hardened
+        description: A suite of production-hardened Helm charts for deploying SPIRE on Kubernetes.
+      - name: SPIRE Identity Exchange
+        type: official
+        weight: 400
+        link: https://github.com/spiffe/spire-identity-exchange
+        description: Standalone service that allows platform-native tokens, such as GitHub Actions or GitLab OIDC tokens, to be exchanged for SPIRE-issued SVIDs.
+      - name: Tornjak
+        type: official
+        weight: 500
+        link: https://github.com/spiffe/tornjak
+        description: A management UI that provides visibility and governance across one or more SPIRE deployments.
+      - name: SPIRE TPM Plugin
+        type: official
+        weight: 600
+        link: https://github.com/spiffe/spire-tpm-plugin
+        description: Agent and server plugins that add TPM 2.0-based node attestation to SPIRE.
+
+  - name: SDKs & Libraries
+    weight: 200
+    description: Fetch and validate SPIFFE identities directly from your application code.
+    projects:
+      - name: go-spiffe
+        type: official
+        weight: 100
+        link: https://github.com/spiffe/go-spiffe
+        description: SPIFFE SDK for Go.
+      - name: java-spiffe
+        type: official
+        weight: 200
+        link: https://github.com/spiffe/java-spiffe
+        description: SPIFFE SDK for Java.
+      - name: c-spiffe
+        type: official
+        weight: 300
+        link: https://github.com/spiffe/c-spiffe
+        description: SPIFFE SDK for C and C++.
+      - name: py-spiffe
+        type: community
+        weight: 400
+        link: https://github.com/HewlettPackard/py-spiffe
+        description: SPIFFE SDK for Python.
+      - name: rust-spiffe
+        type: community
+        weight: 500
+        link: https://github.com/maxlambrecht/rust-spiffe
+        description: SPIFFE SDK for Rust.
+
+  - name: Deployment & Workload Helpers
+    weight: 300
+    description: Deliver SPIFFE identities to workloads, and bridge them to platforms that do not speak the Workload API natively.
+    projects:
+      - name: SPIFFE CSI Driver
+        type: official
+        weight: 100
+        link: https://github.com/spiffe/spiffe-csi
+        description: A Kubernetes CSI driver that exposes the SPIFFE Workload API socket to pods.
+      - name: SPIFFE Helper
+        type: official
+        weight: 200
+        link: https://github.com/spiffe/spiffe-helper
+        description: Fetches and rotates SVIDs to disk for workloads that cannot call the Workload API themselves.
+      - name: AWS SPIFFE Workload Helper
+        type: official
+        weight: 300
+        link: https://github.com/spiffe/aws-spiffe-workload-helper
+        description: Exchanges SPIFFE SVIDs for AWS credentials via IAM Roles Anywhere.
+
+  - name: Secrets Management
+    weight: 400
+    description: Secrets managers that can store secrets and support SPIFFE-authenticated workloads to retrieving them.
+    projects:
+      - name: SPIKE
+        type: official
+        weight: 100
+        link: https://github.com/spiffe/spike
+        description: A SPIFFE-native secrets manage that allows workloads to use SPIFFE authentication to retrieve secrets.
+      - name: VMware Secrets Manager
+        type: community
+        weight: 200
+        link: https://github.com/vmware-tanzu/secrets-manager
+        description: A Kubernetes-native secrets manager with support for SPIFFE authentication.
+      - name: HashiCorp Vault
+        type: commercial
+        weight: 200
+        link: https://developer.hashicorp.com/vault/docs/auth/spiffe
+        description: Secrets manager with support for SPIFFE authentication.
+
+  - name: Service Meshes and Proxies
+    weight: 500
+    description: Service meshes and proxies that use SPIFFE identities to authenticate and secure traffic between workloads.
+    projects:
+      - name: Envoy
+        type: community
+        weight: 100
+        link: https://www.envoyproxy.io/
+        description: Service proxy that can consume SVIDs over the Envoy SDS API to establish mTLS.
+      - name: Istio
+        type: community
+        weight: 200
+        link: https://istio.io/
+        description: Service mesh that issues SPIFFE identities to the workloads in the mesh.
+      - name: Ghostunnel
+        type: community
+        weight: 300
+        link: https://github.com/ghostunnel/ghostunnel
+        description: A TLS proxy that attaches to the SPIFFE Workload API to authenticate connections.
+      - name: HashiCorp Consul
+        type: community
+        weight: 400
+        link: https://www.consul.io/
+        description: Service mesh that can issue SPIFFE identities to the services it manages.

--- a/layouts/shortcodes/ecosystem.html
+++ b/layouts/shortcodes/ecosystem.html
@@ -1,0 +1,39 @@
+{{- /* Renders the SPIFFE Ecosystem listing from data/ecosystem.yaml.
+       Categories and the projects within them are ordered by `weight`.
+       Each project's `type` selects a legend icon. Used by
+       content/docs/latest/spiffe-about/ecosystem.md. */ -}}
+{{- $types := dict
+      "official"   (dict "icon" "fa-star"         "color" "has-text-warning" "label" "SPIFFE official project")
+      "community"  (dict "icon" "fa-people-group" "color" "has-text-info"    "label" "Community project")
+      "commercial" (dict "icon" "fa-sack-dollar"  "color" "has-text-success" "label" "Commercial project")
+-}}
+
+<p class="ecosystem-legend">
+  <strong>Key:</strong>
+  {{- range $key := slice "official" "community" "commercial" }}
+    {{- $t := index $types $key }}
+    <span class="icon-text mr-4">
+      <span class="icon {{ $t.color }}" role="img" aria-label="{{ $t.label }}" title="{{ $t.label }}">
+        <i class="fas {{ $t.icon }}" aria-hidden="true"></i>
+      </span>
+      <span>{{ $t.label }}</span>
+    </span>
+  {{- end }}
+</p>
+
+{{- range sort hugo.Data.ecosystem.categories "weight" }}
+  <h2 id="{{ .name | urlize }}">{{ .name }}</h2>
+  {{- with .description }}
+  <p>{{ . | markdownify }}</p>
+  {{- end }}
+  <ul class="ecosystem-list">
+    {{- range sort .projects "weight" }}
+      {{- $t := index $types .type }}
+      {{- if not $t }}{{ $t = index $types "community" }}{{ end }}
+      <li>
+        <span class="icon {{ $t.color }}" role="img" aria-label="{{ $t.label }}" title="{{ $t.label }}"><i class="fas {{ $t.icon }}" aria-hidden="true"></i></span>
+        <a href="{{ .link }}"><strong>{{ .name }}</strong></a>{{ with .description }} - {{ . | markdownify }}{{ end }}
+      </li>
+    {{- end }}
+  </ul>
+{{- end }}


### PR DESCRIPTION
Introduces the first iteration of the ecosystem page - listing tools/projects/platforms that implement SPIFFE or support SPIFFE. 

I'm hoping to keep this "Ecosystem" page as effectively a high-level, brief, index/directory. Similar to the vein of the various "Awesome" directories that exist for other ecosystems (i.e. https://github.com/avelino/awesome-go, https://github.com/tomhuang12/awesome-k8s-resources)

Eventually, we'll have more context-specific lists that tie into the operators journey when deploying SPIFFE (i.e "Selecting a SPIFFE issuer", "How to integrate SPIFFE to do X in your infrastructure") and I think these pages will provide an opportunity to go into more detail and provide more comparative information as appropriate.

For now, this list is hardly exhaustive - I've started with the most obvious candidates. Most obviously missing at the moment is "SPIFFE Issuers" - I've left these out since this is already covered in more detail on the overview page, and, I think the content around this is due more scrutiny than shipping it as part of this initial PR will provide.

In the next few weeks, I'll set out a bit more of an agenda/overarching information architecture I'd like to propose for the site - my focus at the minute is on getting content together so it's easier to see how we'll need to fit things together.