### PR TITLE
Fix a few styling issues

### DIFF
--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -1,25 +1,6 @@
 document.addEventListener("DOMContentLoaded", function (event) {
     anchors.add();
-  
-    // TODO: We should probably look into updating the tocbot library
-    // but for now we can pad the bottom of the content to make
-    // sure you can scroll into each section of the ToC.
-    var content = $(".content");
-    var lastHeading = content
-      .children()
-      .filter(":header")
-      .sort(function (a, b) {
-        var aTop = a.offsetTop;
-        var bTop = b.offsetTop;
-        return aTop < bTop ? -1 : aTop > bTop ? 1 : 0;
-      })
-      .last()
-      .get(0);
-    var fullHeight = content.outerHeight(true) + content.offset().top;
-    var delta = fullHeight - lastHeading.offsetTop;
-    var padding = window.innerHeight - delta;
-    content.css("paddingBottom", padding + "px");
-  
+
     tocbot.init({
       tocSelector: ".toc",
       contentSelector: ".content",

--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -1,5 +1,3 @@
-$panel-header-logo-width: 85%
-
 html
   overflow: auto
 
@@ -29,21 +27,20 @@ html
   &-panel
     +column
     padding-top: 1rem
-    padding-bottom: 4rem
+    padding-bottom: 1rem
     flex: 0 0 20%
 
-    &-header
-      margin-bottom: 1.5rem
+    &-footer
+      margin-top: 1rem
 
-      &-logo
-        width: $panel-header-logo-width
-        margin: 0.5rem auto 0.5rem auto
-
+    // Horizontal inset is padding (not margin) so the scrollable box spans the
+    // full panel width and its scrollbar sits at the panel edge.
     &-content
+      flex: 1
       +desktop
-        margin: 0 2rem
+        padding: 0 2rem
       +touch
-        margin: 0 1rem
+        padding: 0 1rem
 
 //  Work around for bulma css weird jumbo sized default margin-bottom
 .title:not(:last-child)

--- a/layouts/partials/docs/dashboard-panel.html
+++ b/layouts/partials/docs/dashboard-panel.html
@@ -4,11 +4,15 @@
 {{ $latest     := hugo.Data.releases.latest }}
 
 <div class="dashboard-panel left has-background-white-bis is-hidden-mobile">
-  <div class="dashboard-panel-header has-text-centered">
+  <div class="dashboard-panel-content is-scrollable">
+      {{ partial "docs/sidenav.html" . }}
+  </div>
+
+  <div class="dashboard-panel-footer has-text-centered">
     <div class="dropdown is-left">
       <div class="dropdown-trigger">
         <span class="non-actionable button is-dark" >
-          <span> 
+          <span>
             <strong>
               {{ $latest.name }}
             </strong>
@@ -19,9 +23,5 @@
         </span>
       </div>
     </div>
-  </div>
-
-  <div class="dashboard-panel-content is-scrollable">
-      {{ partial "docs/sidenav.html" . }}
   </div>
 </div>


### PR DESCRIPTION
Fixes:

- Scroll bar in docs side navbar not being aligned with the edge of the navbar.
- Moved the "version" from the header of the navbar down to the footer - this looks/feels much better and avoids the "version" header swallowing up navbar content.
- Removed a hack that added very deep padding to the bottom of each content page. This was designed to allow you to "scroll" the ToC to the bottom. I'm open to reverting this if someone feels strongly about this.

Before:

<img width="1248" height="488" alt="image" src="https://github.com/user-attachments/assets/9cf167b0-e4f2-4b85-b895-57d71126de36" />

After:

<img width="1248" height="488" alt="image" src="https://github.com/user-attachments/assets/9965acda-cde9-4501-9d0e-666884a42c5e" />

