### PR TITLE
build: move Python to 3.12 for Netlify and the linkchecker image

### DIFF
--- a/Dockerfile.linkchecker
+++ b/Dockerfile.linkchecker
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.9-alpine
+FROM docker.io/library/python:3.12-alpine
 
 ENV HOME=/tmp
 ENV PIP_NO_CACHE_DIR=off

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,7 @@ command = "pip install -r requirements.txt && make production-build"
 [build.environment]
 HUGO_VERSION = "0.163.3"
 NODE_VERSION = "22"
+PYTHON_VERSION = "3.12"
 
 [context.deploy-preview]
 command = "pip install -r requirements.txt && make preview-build"


### PR DESCRIPTION
requests >= 2.33.0 requires Python >= 3.10, so the Netlify build (pinned to 3.9 via the UI) and the python:3.9-alpine linkchecker image both fail on Dependabot bumps. PYTHON_VERSION in netlify.toml takes precedence over the UI setting.