### PR TITLE
Clarify bootstrap bundle warning on SPIRE Concepts page

### DIFF
--- a/content/docs/latest/spire-about/spire-concepts.md
+++ b/content/docs/latest/spire-about/spire-concepts.md
@@ -78,7 +78,7 @@ This section walks through a “day in the life” of how SPIRE issues an identi
 6. The agent performs node attestation, to prove to the server the identity of the node it is running on. For example, when running on an AWS EC2 Instance it would typically perform node attestation by supplying an [AWS Instance Identity Document](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html) to the server.  
 7. The agent presents this proof of identity to the server over a TLS connection authenticated via the bootstrap bundle the agent is configured with.
 {{< warning >}}
-This bootstrap bundle is a default configuration, and should be replaced with customer-supplied credentials in production.
+SPIRE ships with a default bootstrap bundle, which the agent uses in step 7 to authenticate the server. In production, replace this default bundle with your own credentials.
 {{< /warning >}}
 8. The server calls the AWS API to validate the proof.
 9. AWS acknowledges the document is valid.

--- a/content/docs/latest/spire-about/spire-concepts.md
+++ b/content/docs/latest/spire-about/spire-concepts.md
@@ -77,9 +77,6 @@ This section walks through a “day in the life” of how SPIRE issues an identi
 5. The SPIRE Agent starts up on the node that the workload is running on.  
 6. The agent performs node attestation, to prove to the server the identity of the node it is running on. For example, when running on an AWS EC2 Instance it would typically perform node attestation by supplying an [AWS Instance Identity Document](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html) to the server.  
 7. The agent presents this proof of identity to the server over a TLS connection authenticated via the bootstrap bundle the agent is configured with.
-{{< warning >}}
-SPIRE ships with a default bootstrap bundle, which the agent uses in step 7 to authenticate the server. In production, replace this default bundle with your own credentials.
-{{< /warning >}}
 8. The server calls the AWS API to validate the proof.
 9. AWS acknowledges the document is valid.
 10. The server performs additional attestation steps to verify further properties about the agent node and update its registration entries accordingly. For example, if the node was attested using an AWS Instance Identity Document (IID), the attestor will perform AWS API requests to get further information for building an additional set of selectors, e.g. autoscale group or instance tag information.


### PR DESCRIPTION
The warning under step 7 of "A Day in the Life of an SVID" referred vaguely to "this bootstrap bundle" as "a default configuration". Reword it to name the bootstrap bundle from step 7 explicitly and state that SPIRE ships a default one that must be replaced with your own credentials in production.

Fixes #213