### PR TITLE
Fix RBAC description for SPIRE Server install on Kubernetes

### DIFF
--- a/content/docs/latest/deploying/install-server.md
+++ b/content/docs/latest/deploying/install-server.md
@@ -58,6 +58,10 @@ See [Install SPIRE Agents](/docs/latest/spire/installing/install-agents/) to lea
 
 This section walks you step-by-step through getting a server running in your Kubernetes cluster and configuring a workload container to access SPIRE.
 
+{{< info >}}
+This walkthrough uses static Kubernetes manifests to teach you how the SPIRE Server's components fit together. For production deployments, use the [SPIRE Helm charts](/docs/latest/spire-helm-charts-hardened-about/), which are the easiest and supported way to deploy and maintain a complete SPIRE stack on Kubernetes.
+{{< /info >}}
+
 {{< warning >}}
 You must run all commands from the directory containing the **.yaml** files used for configuration.
 {{< /warning >}}

--- a/content/docs/latest/deploying/install-server.md
+++ b/content/docs/latest/deploying/install-server.md
@@ -108,7 +108,7 @@ See the following sections for details.
     $ kubectl get serviceaccount --namespace spire
     ```
 
-### Create Server Bundle Configmap, Role & ClusterRoleBinding
+### Create Server Bundle Configmap, Role & ClusterRole
 
 For the server to function, it is necessary for it to provide agents with certificates that they can use to verify the identity of the server when establishing a connection.
 
@@ -126,9 +126,9 @@ In a deployment such as this, where the agent and server share the same cluster,
     $ kubectl get configmaps --namespace spire | grep spire
     ```
 
-To allow the server to read and write to this configmap, a ClusterRole must be created that confers the appropriate entitlements to Kubernetes RBAC, and that ClusterRoleBinding must be associated with the service account created in the previous step.
+To allow the server to read and write to this configmap, a Role must be created that confers the appropriate entitlements to Kubernetes RBAC in the `spire` namespace. The server also needs cluster-wide permissions to perform node attestation: a ClusterRole grants it the ability to get pod and node information and to create tokenreviews, which the server uses to validate agent service account tokens with the Kubernetes Token Review API. A RoleBinding and a ClusterRoleBinding associate the Role and the ClusterRole, respectively, with the service account created in the previous step.
 
-1. Create a ClusterRole named **spire-server-trust-role** and a corresponding ClusterRoleBinding by applying the **server-cluster-role.yaml** configuration file:
+1. Create a Role named **spire-server-configmap-role** and a ClusterRole named **spire-server-trust-role**, together with their corresponding RoleBinding and ClusterRoleBinding, by applying the **server-cluster-role.yaml** configuration file:
 
     ```console
     $ kubectl apply -f server-cluster-role.yaml


### PR DESCRIPTION
The "Create Server Bundle Configmap" section claimed a ClusterRole grants the server read/write access to the spire-bundle configmap. In server-cluster-role.yaml from spire-tutorials/k8s/quickstart, that access is actually granted by a namespaced Role (spire-server-configmap-role); the ClusterRole
(spire-server-trust-role) instead grants get on pods/nodes and create on tokenreviews, which the server needs for node attestation via the Kubernetes Token Review API.

Rewrite the section heading and explanatory sentences to describe the Role, ClusterRole, and their bindings accurately. The kubectl commands are unchanged.

Fixes #310