### PR TITLE
Make docker-serve usable

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,15 +20,16 @@ RUN apt-get update && apt-get install -y \
     && useradd -ms /bin/bash appuser \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-USER appuser
-WORKDIR /app
-
 # Pre-install dependencies during build (optional optimization)
 COPY requirements.txt /tmp/requirements.txt
 # ubuntu:24.04 ships a PEP 668 "externally managed" Python; --break-system-packages
-# is safe here since the container is single-purpose and disposable.
-RUN python3 -m pip install --user --break-system-packages -r /tmp/requirements.txt
+# is safe here since the container is single-purpose and disposable. Installed
+# system-wide (not --user) so it works regardless of which UID the container
+# runs as (e.g. `docker run -u $(id -u):$(id -g)` to match bind-mount ownership).
+RUN python3 -m pip install --break-system-packages -r /tmp/requirements.txt
+
+USER appuser
+WORKDIR /app
 
 # Start with a simple script
 CMD ["bash", "run.sh", "--bind", "0.0.0.0", "--buildDrafts", "--buildFuture", "--disableFastRender", "--ignoreCache", "--noHTTPCache"]

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,14 @@ docker-serve: docker-build
 		-v $(PWD):/app \
 		-p 1313:1313 \
 		-e HIDE_RELEASES=true \
+		-u $(shell id -u):$(shell id -g) \
 		spiffe.io:latest
 
 docker-serve-with-releases: docker-build
 	$(CONTAINER_RUNTIME) run --init --rm \
 		-v $(PWD):/app \
 		-p 1313:1313 \
+		-u $(shell id -u):$(shell id -g) \
 		spiffe.io:latest
 
 pull-external-content:


### PR DESCRIPTION
For me this returns a permission denied error because my user id is different from the one in the container. Specifying the user and group ids when starting the container should work.

Also, at start up it complains about the python yaml dependency not being found so installed things globally instead of in the home dir.