### PR TITLE
Add Google Analytics tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,6 +4,15 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Locale }}">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SC8WXCFW6M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-SC8WXCFW6M');
+    </script>
     {{ partial "meta.html" . }}
     <title>{{ block "title" . }}{{ if .Params.titleTag }}{{ .Params.titleTag }} | {{ .Site.Title }}{{ else if .IsHome }}{{ .Site.Title }} | {{ .Site.Params.acronym }}{{ else if .Title }}{{ .Title }} | {{ .Site.Title }}{{ else }}{{ .Site.Title }}{{ end }}{{ end }}</title>
     <link rel="shortcut icon" href="{{ $favicon }}" type="image/x-icon">


### PR DESCRIPTION
Re-introduces a Google Analytics tag - we had one previously, however, it was severely outdated and therefore not working. I have shared access to the Google Analytics property with all members of SSC.
