### PR TITLE
Move link checker to GHA

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,45 @@
+name: Link check
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: link-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Bulma SASS is imported from node_modules during the Hugo build.
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - run: npm ci
+
+      # Installs linkchecker and pull_external.py's dependencies.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.163.3'
+          extended: true
+
+      # The same advisory check that previously ran during the Netlify build:
+      # serves the site with `hugo server` and crawls it with linkchecker.
+      # GITHUB_TOKEN lets pull_external.py generate the SPIRE releases pages,
+      # which would otherwise be skipped and reported as broken links.
+      - run: make ci-check-links
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,21 +17,21 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # Bulma SASS is imported from node_modules during the Hugo build.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .node-version
       - run: npm ci
 
       # Installs linkchecker and pull_external.py's dependencies.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
       - run: pip install -r requirements.txt
 
-      - uses: peaceiris/actions-hugo@v3
+      - uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: '0.163.3'
           extended: true

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ serve-with-releases:
 		--buildFuture \
 		--disableFastRender
 
-production-build: ci-check-links
+production-build: pull-external-content
 	hugo \
 		--gc \
 		--ignoreCache
 
-preview-build: ci-check-links
+preview-build: pull-external-content
 	hugo \
 		--gc \
 		--ignoreCache \

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The website is now available at [`http://localhost:1313`](http://localhost:1313)
 
 It is common that URLs you are pointing to get deprecated or moved somewhere else over time, leading to broken links on our website.
 
-In order to avoid this, there is a tool that lets you check whether there are broken links in the whole website or not.
+In order to avoid this, there is a tool that lets you check whether there are broken links in the whole website or not. It runs automatically on every pull request via the [Link check](.github/workflows/link-check.yml) GitHub Actions workflow, and you can also run it locally.
 
 First, make sure you are serving the website locally using the `-with-releases` form of the script (`make docker-serve-with-releases` or `make serve-with-releases`), and that it is accessible at `http://localhost:1313`, then run the following command:
 

--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -1,3 +1,9 @@
+# More workers and a shorter timeout keep the CI run fast: with the defaults
+# (10 threads, 60s timeout) a handful of dead hosts stretch the crawl to ~8min.
+[checking]
+threads=20
+timeout=15
+
 [filtering]
 checkextern=1
 ignore=letsencrypt\.org


### PR DESCRIPTION
The link-checker running in Netlify is particularly slow and doesn't surface feedback well on PRs made by external contributors/those who don't have access to Netlify. This PR brings it into GHA where it should be more visible.

In the medium-term, we should switch to something like Lychee (https://github.com/lycheeverse/lychee) and actually address many of our broken links.