### PR TITLE
fix: suggest @jeengbe/spiffe TS library

### DIFF
--- a/content/docs/latest/deploying/libraries.md
+++ b/content/docs/latest/deploying/libraries.md
@@ -24,7 +24,7 @@ This library is not yet part of the official SPIFFE repo.
 
 # Go
 
-See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe) for more information about the SPIFFE Go library. 
+See the [go-spiffe library GitHub page](https://github.com/spiffe/go-spiffe) for more information about the SPIFFE Go library.
 
 * [SPIFFE to SPIFFE authentication using X.509 SVIDs](https://github.com/spiffe/go-spiffe/tree/main/examples/spiffe-tls)
 
@@ -54,5 +54,9 @@ SPIFFE-based authentication and identity integration for applications built on
 `rustls`.
 
 These libraries are not part of the official SPIFFE repository.
+
+# TypeScript/JavaScript
+
+See [`@jeengbe/spiffe`](https://github.com/jeengbe/ts-packages/tree/master/packages/spiffe#readme) for a TypeScript implementation.
 
 {{< scarf/pixels/high-interest >}}

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -60,17 +60,17 @@ categories:
         weight: 200
         link: https://github.com/spiffe/java-spiffe
         description: SPIFFE SDK for Java.
-      - name: py-spiffe
+      - name: HewlettPackard/py-spiffe
         type: community
         weight: 400
         link: https://github.com/HewlettPackard/py-spiffe
         description: SPIFFE SDK for Python.
-      - name: rust-spiffe
+      - name: maclambrecht/rust-spiffe
         type: community
         weight: 500
         link: https://github.com/maxlambrecht/rust-spiffe
         description: SPIFFE SDK for Rust.
-      - name: '@jeengbe/spiffe'
+      - name: 'jeengbe/spiffe'
         type: community
         weight: 600
         link: https://github.com/jeengbe/ts-packages/tree/master/packages/spiffe

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -70,6 +70,11 @@ categories:
         weight: 500
         link: https://github.com/maxlambrecht/rust-spiffe
         description: SPIFFE SDK for Rust.
+      - name: '@jeengbe/spiffe'
+        type: community
+        weight: 600
+        link: https://github.com/jeengbe/ts-packages/tree/master/packages/spiffe
+        description: SPIFFE SDK for TypeScript.
 
   - name: Deployment & Workload Helpers
     weight: 300

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -65,7 +65,7 @@ categories:
         weight: 400
         link: https://github.com/HewlettPackard/py-spiffe
         description: SPIFFE SDK for Python.
-      - name: maclambrecht/rust-spiffe
+      - name: maxlambrecht/rust-spiffe
         type: community
         weight: 500
         link: https://github.com/maxlambrecht/rust-spiffe


### PR DESCRIPTION
I have been working on a JS/TS library to make SPIFFE on Node.js convenient: https://github.com/jeengbe/ts-packages/tree/master/packages/spiffe#readme.

It currently only ships JWT-SVID abstractions (X.509 is still poorly supported within the Node ecosystem in my experience, so I have not gotten to that yet). It ships as ESM, is available on both npm/JSR and includes release provenance. I am currently working on real integration tests.

It is part of a suite of useful TS packages that I maintain. The only alternative I find when I search for "Node SPIFFE" is currently https://github.com/depot/node-spiffe, which is a basic gRPC wrapper with nothing extra. I'm hoping to help more people adopt SPIFFE with a "nice" package 🙂