### PR TITLE
Fix description of K8S SPIFFE Workload Auth Config in ecosystem catalog

### DIFF
--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -99,7 +99,7 @@ categories:
         type: official
         weight: 500
         link: https://github.com/spiffe/k8s-spiffe-workload-auth-config
-        description: Injects the SPIFFE trust bundle into the Kubernetes AuthenticationConfiguration file, allowing the Kubernetes API server to authenticate clients presenting SPIFFE JWTs.
+        description: Injects the SPIFFE trust bundle into the Kubernetes AuthenticationConfiguration file. This allows the Kubernetes API server to read the JWKS from the OIDC discovery provider in cases where it is protected by a SPIFFE-issued certificate.
 
   - name: Secrets Management
     weight: 400

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -99,7 +99,7 @@ categories:
         type: official
         weight: 500
         link: https://github.com/spiffe/k8s-spiffe-workload-auth-config
-        description: Configures Kubernetes clients to use SPIFFE Workload JWT Exec Auth for authentication to the Kubernetes API.
+        description: Injects the SPIFFE trust bundle into the Kubernetes AuthenticationConfiguration file, allowing the Kubernetes API server to authenticate clients presenting SPIFFE JWTs.
 
   - name: Secrets Management
     weight: 400


### PR DESCRIPTION
The current description states that the tool configures Kubernetes clients. It actually manages the kube-apiserver AuthenticationConfiguration file, injecting the SPIFFE trust bundle so that the API server can read the JWKS from the OIDC discovery provider in cases where it is protected by a SPIFFE-issued certificate (per the project README). This updates the description to reflect that, and to make clear the tool is for that specific case rather than a required part of SPIFFE JWT authentication.

Client-side configuration is handled by K8S SPIFFE Workload JWT Exec Auth, which has its own entry in the catalog.